### PR TITLE
Transport stabilization

### DIFF
--- a/include/uxr/agent/datareader/DataReader.hpp
+++ b/include/uxr/agent/datareader/DataReader.hpp
@@ -45,14 +45,14 @@ class Processor;
 /**
  * Callback data structure.
  */
-typedef struct ReadCallbackArgs
+struct ReadCallbackArgs
 {
     dds::xrce::ClientKey client_key;
     dds::xrce::StreamId stream_id;
     dds::xrce::ObjectId object_id;
     dds::xrce::RequestId request_id;
 
-} ReadCallbackArgs;
+};
 
 typedef const std::function<void (const ReadCallbackArgs&, std::vector<uint8_t>)> read_callback;
 

--- a/include/uxr/agent/transport/SerialLayer.hpp
+++ b/include/uxr/agent/transport/SerialLayer.hpp
@@ -29,7 +29,6 @@
 namespace eprosima {
 namespace uxr {
 
-typedef struct SerialInputBuffer SerialInputBuffer;
 struct SerialInputBuffer
 {
     uint8_t buffer[UXR_SERIAL_BUFFER_SIZE];
@@ -39,7 +38,6 @@ struct SerialInputBuffer
     bool stream_init;
 };
 
-typedef struct SerialOutputBuffer SerialOutputBuffer;
 struct SerialOutputBuffer
 {
     uint8_t buffer[UXR_SERIAL_BUFFER_SIZE];

--- a/include/uxr/agent/transport/SerialServerLinux.hpp
+++ b/include/uxr/agent/transport/SerialServerLinux.hpp
@@ -70,6 +70,7 @@ private:
     int errno_;
     std::unordered_map<uint8_t, uint32_t> source_to_client_map_;
     std::unordered_map<uint32_t, uint8_t> client_to_source_map_;
+    std::mutex clients_mtx_;
 };
 
 } // namespace uxr

--- a/include/uxr/agent/transport/TCPServerLinux.hpp
+++ b/include/uxr/agent/transport/TCPServerLinux.hpp
@@ -120,7 +120,7 @@ private:
     std::mutex clients_mtx_;
     std::unique_ptr<std::thread> listener_thread_;
     std::atomic<bool> running_cond_;
-    std::queue<InputPacket> messages_queue;
+    std::queue<InputPacket> messages_queue_;
 };
 
 } // namespace uxr

--- a/include/uxr/agent/transport/TCPServerLinux.hpp
+++ b/include/uxr/agent/transport/TCPServerLinux.hpp
@@ -18,9 +18,12 @@
 #include <uxr/agent/transport/Server.hpp>
 #include <uxr/agent/config.hpp>
 #include <unordered_map>
+#include <netinet/in.h>
 #include <sys/poll.h>
 #include <vector>
 #include <array>
+#include <list>
+#include <set>
 
 namespace eprosima {
 namespace uxr {
@@ -38,7 +41,6 @@ typedef enum TCPInputBufferState
 
 } TCPInputBufferState;
 
-typedef struct TCPInputBuffer TCPInputBuffer;
 struct TCPInputBuffer
 {
     std::vector<uint8_t> buffer;
@@ -50,12 +52,12 @@ struct TCPInputBuffer
 struct TCPConnection
 {
     struct pollfd* poll_fd;
-    TCPConnection* next;
-    TCPConnection* prev;
     TCPInputBuffer input_buffer;
     uint32_t addr;
     uint16_t port;
     uint32_t id;
+    bool active;
+    std::mutex mtx;
 };
 
 class TCPEndPoint : public EndPoint
@@ -92,22 +94,33 @@ private:
     virtual bool recv_message(InputPacket& input_packet, int timeout) override;
     virtual bool send_message(OutputPacket output_packet) override;
     virtual int get_error() override;
-    uint16_t read_data(TCPConnection* connection);
-    bool disconnect_client(TCPConnection* connection);
-    static void init_input_buffer(TCPInputBuffer* buffer);
+    bool read_message(int timeout);
+    uint16_t read_data(TCPConnection& connection);
+    bool open_connection(int fd, struct sockaddr_in* sockaddr);
+    bool close_connection(TCPConnection& connection);
+    bool connection_available();
+    void listener_loop();
+    static void init_input_buffer(TCPInputBuffer& buffer);
     static void sigpipe_handler(int fd) { (void)fd; }
+    static ssize_t recv_locking(TCPConnection& connection, void* buffer, size_t len);
+    static ssize_t send_locking(TCPConnection& connection, void* buffer, size_t len);
 
 private:
     uint16_t port_;
     std::array<TCPConnection, TCP_MAX_CONNECTIONS> connections_;
-    TCPConnection* active_connections_;
-    TCPConnection* free_connections_;
-    TCPConnection* last_connection_read_;
-    std::array<struct pollfd, TCP_MAX_CONNECTIONS + 1> poll_fds_;
+    std::set<uint32_t> active_connections_;
+    std::list<uint32_t> free_connections_;
+    std::mutex connections_mtx_;
+    struct pollfd listener_poll_;
+    std::array<struct pollfd, TCP_MAX_CONNECTIONS> poll_fds_;
     uint8_t buffer_[TCP_TRANSPORT_MTU];
     std::unordered_map<uint64_t, uint32_t> source_to_connection_map_;
     std::unordered_map<uint64_t, uint32_t> source_to_client_map_;
     std::unordered_map<uint32_t, uint64_t> client_to_source_map_;
+    std::mutex clients_mtx_;
+    std::unique_ptr<std::thread> listener_thread_;
+    std::atomic<bool> running_cond_;
+    std::queue<InputPacket> messages_queue;
 };
 
 } // namespace uxr

--- a/include/uxr/agent/transport/TCPServerWindows.hpp
+++ b/include/uxr/agent/transport/TCPServerWindows.hpp
@@ -38,7 +38,6 @@ typedef enum TCPInputBufferState
 
 } TCPInputBufferState;
 
-typedef struct TCPInputBuffer TCPInputBuffer;
 struct TCPInputBuffer
 {
     std::vector<uint8_t> buffer;

--- a/include/uxr/agent/transport/UDPServerLinux.hpp
+++ b/include/uxr/agent/transport/UDPServerLinux.hpp
@@ -69,6 +69,7 @@ private:
     uint8_t buffer_[UDP_TRANSPORT_MTU];
     std::unordered_map<uint64_t, uint32_t> source_to_client_map_;
     std::unordered_map<uint32_t, uint64_t> client_to_source_map_;
+    std::mutex clients_mtx_;
 };
 
 } // namespace uxr

--- a/include/uxr/agent/transport/UDPServerWindows.hpp
+++ b/include/uxr/agent/transport/UDPServerWindows.hpp
@@ -69,6 +69,7 @@ private:
     uint8_t buffer_[UDP_TRANSPORT_MTU];
     std::unordered_map<uint64_t, uint32_t> source_to_client_map_;
     std::unordered_map<uint32_t, uint64_t> client_to_source_map_;
+    std::mutex clients_mtx_;
 };
 
 } // namespace uxr

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -419,17 +419,17 @@ bool Processor::process_acknack_submessage(ProxyClient& client, InputPacket& inp
         {
             OutputPacket output_packet;
             output_packet.destination = input_packet.source;
-            uint8_t mask = 0x01 << i;
+            uint8_t mask = uint8_t(0x01 << i);
             if ((nack_bitmap.at(1) & mask) == mask)
             {
-                if (client.session().get_output_message((uint8_t) seq_num, first_message + i, output_packet.message))
+                if (client.session().get_output_message(uint8_t(seq_num), first_message + i, output_packet.message))
                 {
                     server_->push_output_packet(output_packet);
                 }
             }
             if ((nack_bitmap.at(0) & mask) == mask)
             {
-                if (client.session().get_output_message((uint8_t) seq_num, first_message + i + 8, output_packet.message))
+                if (client.session().get_output_message(uint8_t(seq_num), first_message + i + 8, output_packet.message))
                 {
                     server_->push_output_packet(output_packet);
                 }
@@ -437,7 +437,7 @@ bool Processor::process_acknack_submessage(ProxyClient& client, InputPacket& inp
         }
 
         /* Update output stream. */
-        client.session().update_from_acknack((uint8_t) seq_num, first_message);
+        client.session().update_from_acknack(uint8_t(seq_num), first_message);
     }
     else
     {

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -553,11 +553,14 @@ void Processor::check_heartbeats()
                 /* Set output packet and serialize HEARTBEAT. */
                 OutputPacket output_packet;
                 output_packet.destination = server_->get_source(client->get_client_key());
-                output_packet.message = OutputMessagePtr(new OutputMessage(heartbeat_header));
-                output_packet.message->append_submessage(dds::xrce::HEARTBEAT, heartbeat_payload);
+                if (output_packet.destination)
+                {
+                    output_packet.message = OutputMessagePtr(new OutputMessage(heartbeat_header));
+                    output_packet.message->append_submessage(dds::xrce::HEARTBEAT, heartbeat_payload);
 
-                /* Send message. */
-                server_->push_output_packet(output_packet);
+                    /* Send message. */
+                    server_->push_output_packet(output_packet);
+                }
             }
         }
     }

--- a/src/cpp/transport/SerialServerLinux.cpp
+++ b/src/cpp/transport/SerialServerLinux.cpp
@@ -37,6 +37,7 @@ void SerialServer::on_create_client(EndPoint* source, const dds::xrce::ClientKey
     uint32_t client_id = client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24);
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it_client = client_to_source_map_.find(client_id);
     if (it_client != client_to_source_map_.end())
     {
@@ -65,6 +66,7 @@ void SerialServer::on_delete_client(EndPoint* source)
     uint8_t source_id = endpoint->get_addr();
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = source_to_client_map_.find(source_id);
     if (it != source_to_client_map_.end())
     {
@@ -77,6 +79,7 @@ const dds::xrce::ClientKey SerialServer::get_client_key(EndPoint* source)
 {
     dds::xrce::ClientKey client_key;
     SerialEndPoint* endpoint = static_cast<SerialEndPoint*>(source);
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = source_to_client_map_.find(endpoint->get_addr());
     if (it != source_to_client_map_.end())
     {
@@ -96,6 +99,7 @@ std::unique_ptr<EndPoint> SerialServer::get_source(const dds::xrce::ClientKey& c
 {
     std::unique_ptr<EndPoint> source;
     uint32_t client_id = client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24);
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = client_to_source_map_.find(client_id);
     if (it != client_to_source_map_.end())
     {

--- a/src/cpp/transport/Server.cpp
+++ b/src/cpp/transport/Server.cpp
@@ -78,7 +78,10 @@ void Server::stop()
 
 void Server::push_output_packet(OutputPacket output_packet)
 {
-    output_scheduler_.push(std::move(output_packet), 0);
+    if (output_packet.destination && output_packet.message)
+    {
+        output_scheduler_.push(std::move(output_packet), 0);
+    }
 }
 
 void Server::receiver_loop()

--- a/src/cpp/transport/TCPServerLinux.cpp
+++ b/src/cpp/transport/TCPServerLinux.cpp
@@ -15,12 +15,12 @@
 #include <uxr/agent/transport/TCPServerLinux.hpp>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
 #include <signal.h>
+#include <functional>
 
 namespace eprosima {
 namespace uxr {
@@ -30,12 +30,16 @@ TCPServer::TCPServer(uint16_t port)
       connections_{},
       active_connections_(),
       free_connections_(),
-      last_connection_read_(),
+      listener_poll_{},
       poll_fds_{},
       buffer_{0},
       source_to_connection_map_{},
       source_to_client_map_{},
-      client_to_source_map_{}
+      client_to_source_map_{},
+      clients_mtx_(),
+      listener_thread_(),
+      running_cond_(false),
+      messages_queue{}
 {}
 
 void TCPServer::on_create_client(EndPoint* source, const dds::xrce::ClientKey& client_key)
@@ -45,6 +49,7 @@ void TCPServer::on_create_client(EndPoint* source, const dds::xrce::ClientKey& c
     uint32_t client_id = client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24);
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it_client = client_to_source_map_.find(client_id);
     if (it_client != client_to_source_map_.end())
     {
@@ -73,6 +78,7 @@ void TCPServer::on_delete_client(EndPoint* source)
     uint64_t source_id = (endpoint->get_addr() << 16) | endpoint->get_port();
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = source_to_client_map_.find(source_id);
     if (it != source_to_client_map_.end())
     {
@@ -85,6 +91,7 @@ const dds::xrce::ClientKey TCPServer::get_client_key(EndPoint* source)
 {
     dds::xrce::ClientKey client_key;
     TCPEndPoint* endpoint = static_cast<TCPEndPoint*>(source);
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = source_to_client_map_.find(((uint64_t)endpoint->get_addr() << 16) | endpoint->get_port());
     if (it != source_to_client_map_.end())
     {
@@ -104,6 +111,7 @@ std::unique_ptr<EndPoint> TCPServer::get_source(const dds::xrce::ClientKey& clie
 {
     std::unique_ptr<EndPoint> source;
     uint32_t client_id = client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24);
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = client_to_source_map_.find(client_id);
     if (it != client_to_source_map_.end())
     {
@@ -120,14 +128,10 @@ bool TCPServer::init()
     /* Ignore SIGPIPE signal. */
     signal(SIGPIPE, sigpipe_handler);
 
-    /* Socket initialization. */
-    poll_fds_[0].fd = socket(PF_INET, SOCK_STREAM, 0);
+    /* Listener socket initialization. */
+    listener_poll_.fd = socket(PF_INET, SOCK_STREAM, 0);
 
-    if (-1 == poll_fds_[0].fd)
-    {
-        rv = errno;
-    }
-    else
+    if (-1 != listener_poll_.fd)
     {
         /* IP and Port setup. */
         struct sockaddr_in address;
@@ -135,37 +139,28 @@ bool TCPServer::init()
         address.sin_port = htons(port_);
         address.sin_addr.s_addr = INADDR_ANY;
         memset(address.sin_zero, '\0', sizeof(address.sin_zero));
-        if (-1 != bind(poll_fds_[0].fd, (struct sockaddr*)&address, sizeof(address)))
+        if (-1 != bind(listener_poll_.fd, (struct sockaddr*)&address, sizeof(address)))
         {
-            /* Listen Poll setup. */
-            poll_fds_[0].events = POLLIN;
+            /* Setup listener poll. */
+            listener_poll_.events = POLLIN;
 
-            /* Client polls setup. */
-            for (unsigned int i = 1; i < poll_fds_.size(); ++i)
+            /* Setup connections. */
+            for (size_t i = 0; i < poll_fds_.size(); ++i)
             {
                 poll_fds_[i].fd = -1;
                 poll_fds_[i].events = POLLIN;
+                connections_[i].poll_fd = &poll_fds_[i];
+                connections_[i].id = uint32_t(i);
+                connections_[i].active = false;
+                init_input_buffer(connections_[i].input_buffer);
+                free_connections_.push_back(connections_[i].id);
             }
 
-            /* Listener setup. */
-            if (-1 != listen(poll_fds_[0].fd, TCP_MAX_BACKLOG_CONNECTIONS))
+            /* Init listener. */
+            if (-1 != listen(listener_poll_.fd, TCP_MAX_BACKLOG_CONNECTIONS))
             {
-                /* Client setup. */
-                connections_[0].poll_fd = &poll_fds_[1];
-                connections_[0].id = 0;
-                init_input_buffer(&connections_[0].input_buffer);
-                for (unsigned int i = 1; i < poll_fds_.size() - 1; ++i)
-                {
-                    connections_[i].poll_fd = &poll_fds_[i + 1];
-                    init_input_buffer(&connections_[i].input_buffer);
-                    connections_[i - 1].next = &connections_[i];
-                    connections_[i].prev = &connections_[i - 1];
-                    connections_[i].id = static_cast<uint32_t>(i);
-                }
-                connections_.back().next = &connections_.front();
-                connections_.front().prev = &connections_.back();
-                free_connections_ = &connections_[0];
-                last_connection_read_ = free_connections_;
+                running_cond_ = true;
+                listener_thread_.reset(new std::thread(std::bind(&TCPServer::listener_loop, this)));
                 rv = true;
             }
         }
@@ -177,105 +172,38 @@ bool TCPServer::close()
 {
     bool rv = false;
 
-    /* Close listener. */
-    if (0 == ::close(poll_fds_[0].fd))
+    /* Stop listener thread. */
+    running_cond_ = false;
+    if (listener_thread_ && listener_thread_->joinable())
     {
-        /* Disconnect clients. */
-        while (nullptr != active_connections_)
+        /* Close listener. */
+        listener_thread_->join();
+        if (0 == ::close(listener_poll_.fd))
         {
-            if (!disconnect_client(active_connections_))
+            /* Disconnect clients. */
+            for (auto& conn : connections_)
             {
-                break;
+                close_connection(conn);
             }
+            std::lock_guard<std::mutex> lock(connections_mtx_);
+            rv = active_connections_.empty();
         }
-        rv = (nullptr == active_connections_);
     }
+
     return rv;
 }
 
 bool TCPServer::recv_message(InputPacket& input_packet, int timeout)
 {
-    bool rv = false;
-    int poll_rv = poll(poll_fds_.data(), poll_fds_.size(), timeout);
-    if (0 < poll_rv)
+    bool rv = true;
+    if (messages_queue.empty() && !read_message(timeout))
     {
-        if (POLLIN == (POLLIN & poll_fds_[0].revents) && nullptr != free_connections_)
-        {
-            /* New client connection. */
-            struct sockaddr client_addr;
-            socklen_t client_addr_len = sizeof(client_addr);
-            int incoming_fd = accept(poll_fds_[0].fd, &client_addr, &client_addr_len);
-            if (-1 != incoming_fd)
-            {
-                /* Update available clients list. */
-                TCPConnection* incoming_connection = free_connections_;
-                incoming_connection->poll_fd->fd = incoming_fd;
-                incoming_connection->addr = ((struct sockaddr_in*)&client_addr)->sin_addr.s_addr;
-                incoming_connection->port = ((struct sockaddr_in*)&client_addr)->sin_port;
-                if (free_connections_ != free_connections_->next)
-                {
-                    free_connections_->prev->next = free_connections_->next;
-                    free_connections_->next->prev = free_connections_->prev;
-                    free_connections_ = free_connections_->next;
-                }
-                else
-                {
-                    free_connections_ = nullptr;
-                }
-
-                /* Update connected client list. */
-                if (nullptr != active_connections_)
-                {
-                    incoming_connection->prev = active_connections_->prev;
-                    incoming_connection->next = active_connections_;
-                    active_connections_->prev->next = incoming_connection;
-                    active_connections_->prev = incoming_connection;
-                }
-                else
-                {
-                    incoming_connection->prev = incoming_connection;
-                    incoming_connection->next = incoming_connection;
-                    active_connections_ = incoming_connection;
-                    last_connection_read_ = incoming_connection;
-                }
-                uint64_t source_id = ((uint64_t)incoming_connection->addr << 16) | incoming_connection->port;
-                source_to_connection_map_.insert(std::make_pair(source_id, incoming_connection->id));
-            }
-        }
-        else
-        {
-            if (nullptr != active_connections_)
-            {
-                /**
-                 * Receive Scheduler: the first client in attemp to read will be the neighbour of
-                 *                    the last client form which data was read.
-                 */
-                TCPConnection* base_connection = last_connection_read_->next;
-                TCPConnection* reader = last_connection_read_->next;
-                do
-                {
-                    if (POLLIN == (POLLIN & reader->poll_fd->revents))
-                    {
-                        uint16_t bytes_read = read_data(reader);
-                        if (0 < bytes_read)
-                        {
-                            input_packet.message.reset(new InputMessage(reader->input_buffer.buffer.data(), bytes_read));
-                            last_connection_read_ = reader;
-                            input_packet.source.reset(new TCPEndPoint(reader->addr, reader->port));
-                            rv = true;
-                            break;
-                        }
-                    }
-                    reader = reader->next;
-
-                }
-                while (reader != base_connection);
-            }
-        }
+        rv = false;
     }
-    else if (0 == poll_rv)
+    else
     {
-        errno = ETIME;
+        input_packet = std::move(messages_queue.front());
+        messages_queue.pop();
     }
     return rv;
 }
@@ -289,24 +217,26 @@ bool TCPServer::send_message(OutputPacket output_packet)
     const TCPEndPoint* destination = static_cast<const TCPEndPoint*>(output_packet.destination.get());
     uint64_t source_id = ((uint64_t)destination->get_addr() << 16) | destination->get_port();
 
+    std::unique_lock<std::mutex> lock(connections_mtx_);
     auto it = source_to_connection_map_.find(source_id);
     if (it != source_to_connection_map_.end())
     {
         TCPConnection& connection = connections_.at(it->second);
+        lock.unlock();
 
         /* Send message size. */
         msg_size_buf[0] = (uint8_t)(0x00FF & output_packet.message->get_len());
         msg_size_buf[1] = (uint8_t)((0xFF00 & output_packet.message->get_len()) >> 8);
         do
         {
-            send_rv = send(connection.poll_fd->fd, msg_size_buf, 2, 0);
+            send_rv = send_locking(connection, msg_size_buf, 2);
             if (0 <= send_rv)
             {
                 bytes_sent += send_rv;
             }
             else
             {
-                disconnect_client(&connection);
+                close_connection(connection);
                 rv = false;
             }
         }
@@ -318,16 +248,16 @@ bool TCPServer::send_message(OutputPacket output_packet)
             bytes_sent = 0;
             do
             {
-                send_rv = send(connection.poll_fd->fd,
-                               output_packet.message->get_buf() + bytes_sent,
-                               output_packet.message->get_len() - bytes_sent, 0);
+                send_rv = send_locking(connection,
+                                       output_packet.message->get_buf() + bytes_sent,
+                                       output_packet.message->get_len() - bytes_sent);
                 if (0 <= send_rv)
                 {
                     bytes_sent += send_rv;
                 }
                 else
                 {
-                    disconnect_client(&connection);
+                    close_connection(connection);
                     rv = false;
                 }
             }
@@ -343,7 +273,7 @@ int TCPServer::get_error()
     return errno;
 }
 
-uint16_t TCPServer::read_data(TCPConnection* connection)
+uint16_t TCPServer::read_data(TCPConnection& connection)
 {
     uint16_t rv = 0;
     bool exit_flag = false;
@@ -351,32 +281,32 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
     /* State Machine. */
     while(!exit_flag)
     {
-        switch (connection->input_buffer.state)
+        switch (connection.input_buffer.state)
         {
             case TCP_BUFFER_EMPTY:
             {
-                connection->input_buffer.position = 0;
+                connection.input_buffer.position = 0;
                 uint8_t size_buf[2];
-                ssize_t bytes_received = recv(connection->poll_fd->fd, size_buf, 2, 0);
+                ssize_t bytes_received = recv_locking(connection, size_buf, 2);
                 if (0 < bytes_received)
                 {
-                    connection->input_buffer.msg_size = 0;
+                    connection.input_buffer.msg_size = 0;
                     if (2 == bytes_received)
                     {
-                        connection->input_buffer.msg_size = (uint16_t)(size_buf[1] << 8) | (uint16_t)size_buf[0];
-                        if (connection->input_buffer.msg_size != 0)
+                        connection.input_buffer.msg_size = (uint16_t)(size_buf[1] << 8) | (uint16_t)size_buf[0];
+                        if (connection.input_buffer.msg_size != 0)
                         {
-                            connection->input_buffer.state = TCP_SIZE_READ;
+                            connection.input_buffer.state = TCP_SIZE_READ;
                         }
                         else
                         {
-                            connection->input_buffer.state = TCP_BUFFER_EMPTY;
+                            connection.input_buffer.state = TCP_BUFFER_EMPTY;
                         }
                     }
                     else
                     {
-                        connection->input_buffer.msg_size = (uint16_t)size_buf[0];
-                        connection->input_buffer.state = TCP_SIZE_INCOMPLETE;
+                        connection.input_buffer.msg_size = (uint16_t)size_buf[0];
+                        connection.input_buffer.state = TCP_SIZE_INCOMPLETE;
                     }
                 }
                 else
@@ -385,26 +315,25 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
                     {
                         errno = ENOTCONN;
                     }
-                    disconnect_client(connection);
+                    close_connection(connection);
                     exit_flag = true;
                 }
-                exit_flag = (0 == poll(connection->poll_fd, 1, 0));
                 break;
             }
             case TCP_SIZE_INCOMPLETE:
             {
                 uint8_t size_msb;
-                ssize_t bytes_received = recv(connection->poll_fd->fd, &size_msb, 1, 0);
+                ssize_t bytes_received = recv_locking(connection, &size_msb, 1);
                 if (0 < bytes_received)
                 {
-                    connection->input_buffer.msg_size = (uint16_t)(size_msb << 8) | connection->input_buffer.msg_size;
-                    if (connection->input_buffer.msg_size != 0)
+                    connection.input_buffer.msg_size = (uint16_t)(size_msb << 8) | connection.input_buffer.msg_size;
+                    if (connection.input_buffer.msg_size != 0)
                     {
-                        connection->input_buffer.state = TCP_SIZE_READ;
+                        connection.input_buffer.state = TCP_SIZE_READ;
                     }
                     else
                     {
-                        connection->input_buffer.state = TCP_BUFFER_EMPTY;
+                        connection.input_buffer.state = TCP_BUFFER_EMPTY;
                     }
                 }
                 else
@@ -413,28 +342,28 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
                     {
                         errno = ENOTCONN;
                     }
-                    disconnect_client(connection);
+                    close_connection(connection);
                     exit_flag = true;
                 }
-                exit_flag = (0 == poll(connection->poll_fd, 1, 0));
+                exit_flag = (0 == poll(connection.poll_fd, 1, 0));
                 break;
             }
             case TCP_SIZE_READ:
             {
-                connection->input_buffer.buffer.resize(connection->input_buffer.msg_size);
-                ssize_t bytes_received = recv(connection->poll_fd->fd,
-                                              connection->input_buffer.buffer.data(),
-                                              connection->input_buffer.buffer.size(), 0);
+                connection.input_buffer.buffer.resize(connection.input_buffer.msg_size);
+                ssize_t bytes_received = recv_locking(connection,
+                                                      connection.input_buffer.buffer.data(),
+                                                      connection.input_buffer.buffer.size());
                 if (0 < bytes_received)
                 {
-                    if ((uint16_t)bytes_received == connection->input_buffer.msg_size)
+                    if ((uint16_t)bytes_received == connection.input_buffer.msg_size)
                     {
-                        connection->input_buffer.state = TCP_MESSAGE_AVAILABLE;
+                        connection.input_buffer.state = TCP_MESSAGE_AVAILABLE;
                     }
                     else
                     {
-                        connection->input_buffer.position = (uint16_t)bytes_received;
-                        connection->input_buffer.state = TCP_MESSAGE_INCOMPLETE;
+                        connection.input_buffer.position = (uint16_t)bytes_received;
+                        connection.input_buffer.state = TCP_MESSAGE_INCOMPLETE;
                         exit_flag = true;
                     }
                 }
@@ -444,22 +373,22 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
                     {
                         errno = ENOTCONN;
                     }
-                    disconnect_client(connection);
+                    close_connection(connection);
                     exit_flag = true;
                 }
                 break;
             }
             case TCP_MESSAGE_INCOMPLETE:
             {
-                ssize_t bytes_received = recv(connection->poll_fd->fd,
-                                              connection->input_buffer.buffer.data() + connection->input_buffer.position,
-                                              connection->input_buffer.buffer.size() - connection->input_buffer.position, 0);
+                ssize_t bytes_received = recv_locking(connection,
+                                                      connection.input_buffer.buffer.data() + connection.input_buffer.position,
+                                                      connection.input_buffer.buffer.size() - connection.input_buffer.position);
                 if (0 < bytes_received)
                 {
-                    connection->input_buffer.position += (uint16_t)bytes_received;
-                    if (connection->input_buffer.position == connection->input_buffer.msg_size)
+                    connection.input_buffer.position += (uint16_t)bytes_received;
+                    if (connection.input_buffer.position == connection.input_buffer.msg_size)
                     {
-                        connection->input_buffer.state = TCP_MESSAGE_AVAILABLE;
+                        connection.input_buffer.state = TCP_MESSAGE_AVAILABLE;
                     }
                     else
                     {
@@ -472,15 +401,15 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
                     {
                         errno = ENOTCONN;
                     }
-                    disconnect_client(connection);
+                    close_connection(connection);
                     exit_flag = true;
                 }
                 break;
             }
             case TCP_MESSAGE_AVAILABLE:
             {
-                rv = connection->input_buffer.msg_size;
-                connection->input_buffer.state = TCP_BUFFER_EMPTY;
+                rv = connection.input_buffer.msg_size;
+                connection.input_buffer.state = TCP_BUFFER_EMPTY;
                 exit_flag = true;
                 break;
             }
@@ -494,63 +423,155 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
     return rv;
 }
 
-bool TCPServer::disconnect_client(TCPConnection* connection)
+bool TCPServer::open_connection(int fd, struct sockaddr_in* sockaddr)
 {
     bool rv = false;
-    if (0 == ::close(connection->poll_fd->fd))
+    std::lock_guard<std::mutex> lock(connections_mtx_);
+    if (!free_connections_.empty())
     {
-        if (nullptr != free_connections_)
-        {
-            if (connection != connection->next)
-            {
-                /* Remove from connected_clients_. */
-                connection->prev->next = connection->next;
-                connection->next->prev = connection->prev;
-            }
-            else
-            {
-                active_connections_ = nullptr;
-            }
+        size_t id = size_t(free_connections_.front());
+        TCPConnection& connection = connections_[id];
+        connection.poll_fd->fd = fd;
+        connection.addr = sockaddr->sin_addr.s_addr;
+        connection.port = sockaddr->sin_port;
+        connection.active = true;
 
-            /* Add to free connections. */
-            connection->next = free_connections_;
-            connection->prev = free_connections_->prev;
-            free_connections_->prev->next = connection;
-            free_connections_->prev = connection;
-
-            /* Reset last connection read if necessary. */
-            if (connection == last_connection_read_)
-            {
-                last_connection_read_ = active_connections_;
-            }
-        }
-        else
-        {
-            connection->next = connection;
-            connection->prev = connection;
-            free_connections_ = connection;
-        }
-        connection->poll_fd->fd = -1;
-
-        /* Free connection maps. */
-        uint64_t source_id = ((uint64_t)connection->addr << 16) | connection->port;
-        auto it = source_to_client_map_.find(source_id);
-        if (it != source_to_client_map_.end())
-        {
-            source_to_connection_map_.erase(it->first);
-            source_to_client_map_.erase(it->first);
-            client_to_source_map_.erase(it->second);
-        }
+        uint64_t source_id = (uint64_t(connection.addr) << 16) | connection.port;
+        source_to_connection_map_[source_id] = connection.id;
+        active_connections_.insert(id);
+        free_connections_.pop_front();
         rv = true;
     }
-
     return rv;
 }
 
-void TCPServer::init_input_buffer(TCPInputBuffer* buffer)
+bool TCPServer::close_connection(TCPConnection& connection)
 {
-    buffer->state = TCP_BUFFER_EMPTY;
-    buffer->msg_size = 0;
+    bool rv = false;
+    std::unique_lock<std::mutex> lock(connections_mtx_);
+    auto it_conn = active_connections_.find(connection.id);
+    if (it_conn != active_connections_.end())
+    {
+        lock.unlock();
+        /* Add lock for close. */
+        std::unique_lock<std::mutex> conn_lock(connection.mtx);
+        if (0 == ::close(connection.poll_fd->fd))
+        {
+            connection.poll_fd->fd = -1;
+            connection.active = false;
+            conn_lock.unlock();
+
+            uint64_t source_id = (uint64_t(connection.addr) << 16) | connection.port;
+            /* Clear connections map and lists. */
+            lock.lock();
+            source_to_connection_map_.erase(source_id);
+            active_connections_.erase(it_conn);
+            free_connections_.push_back(connection.id);
+            lock.unlock();
+
+            std::unique_lock<std::mutex> client_lock(clients_mtx_);
+            auto it_client = source_to_client_map_.find(source_id);
+            if (it_client != source_to_client_map_.end())
+            {
+                client_to_source_map_.erase(it_client->second);
+                source_to_client_map_.erase(it_client->first);
+            }
+            rv = true;
+        }
+    }
+    return rv;
+}
+
+void TCPServer::init_input_buffer(TCPInputBuffer& buffer)
+{
+    buffer.state = TCP_BUFFER_EMPTY;
+    buffer.msg_size = 0;
+}
+
+bool TCPServer::read_message(int timeout)
+{
+    bool rv = false;
+    int poll_rv = poll(poll_fds_.data(), poll_fds_.size(), timeout);
+    if (0 < poll_rv)
+    {
+        for (auto& conn : connections_)
+        {
+            if (POLLIN == (POLLIN & conn.poll_fd->revents))
+            {
+                uint16_t bytes_read = read_data(conn);
+                if (0 < bytes_read)
+                {
+                    InputPacket input_packet;
+                    input_packet.message.reset(new InputMessage(conn.input_buffer.buffer.data(), bytes_read));
+                    input_packet.source.reset(new TCPEndPoint(conn.addr, conn.port));
+                    messages_queue.push(std::move(input_packet));
+                    rv = true;
+                }
+            }
+        }
+    }
+    else
+    {
+        if (0 == poll_rv)
+        {
+            errno = ETIME;
+        }
+    }
+    return rv;
+}
+
+void TCPServer::listener_loop()
+{
+    while (running_cond_)
+    {
+        int poll_rv = poll(&listener_poll_, 1, 100);
+        if (0 < poll_rv)
+        {
+            if (POLLIN == (POLLIN & listener_poll_.revents))
+            {
+                if (connection_available())
+                {
+                    /* New client connection. */
+                    struct sockaddr client_addr;
+                    socklen_t client_addr_len = sizeof(client_addr);
+                    int incoming_fd = accept(listener_poll_.fd, &client_addr, &client_addr_len);
+                    if (-1 != incoming_fd)
+                    {
+                        /* Open connection. */
+                        open_connection(incoming_fd, (struct sockaddr_in*)&client_addr);
+                    }
+                }
+            }
+        }
+    }
+}
+
+bool TCPServer::connection_available()
+{
+    std::lock_guard<std::mutex> lock(connections_mtx_);
+    return !free_connections_.empty();
+}
+
+ssize_t TCPServer::recv_locking(TCPConnection& connection, void* buffer, size_t len)
+{
+    ssize_t rv = 0;
+    std::lock_guard<std::mutex> lock(connection.mtx);
+    if (connection.active)
+    {
+        rv = recv(connection.poll_fd->fd, buffer, len, 0);
+    }
+    return rv;
+}
+
+ssize_t TCPServer::send_locking(TCPConnection& connection, void* buffer, size_t len)
+{
+    ssize_t rv = 0;
+    std::lock_guard<std::mutex> lock(connection.mtx);
+    if (connection.active)
+    {
+        rv = send(connection.poll_fd->fd, buffer, len, 0);
+    }
+    return rv;
 }
 
 } // namespace uxr

--- a/src/cpp/transport/TCPServerWindows.cpp
+++ b/src/cpp/transport/TCPServerWindows.cpp
@@ -23,12 +23,16 @@ TCPServer::TCPServer(uint16_t port)
       connections_{},
       active_connections_(),
       free_connections_(),
-      last_connection_read_(),
+      listener_poll_{},
       poll_fds_{},
       buffer_{0},
       source_to_connection_map_{},
       source_to_client_map_{},
-      client_to_source_map_{}
+      client_to_source_map_{},
+      clients_mtx_(),
+      listener_thread_(),
+      running_cond_(false),
+      messages_queue_{}
 {}
 
 void TCPServer::on_create_client(EndPoint* source, const dds::xrce::ClientKey& client_key)
@@ -38,6 +42,7 @@ void TCPServer::on_create_client(EndPoint* source, const dds::xrce::ClientKey& c
     uint32_t client_id = uint32_t(client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24));
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it_client = client_to_source_map_.find(client_id);
     if (it_client != client_to_source_map_.end())
     {
@@ -66,6 +71,7 @@ void TCPServer::on_delete_client(EndPoint* source)
     uint64_t source_id = (endpoint->get_addr() << 16) | endpoint->get_port();
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = source_to_client_map_.find(source_id);
     if (it != source_to_client_map_.end())
     {
@@ -78,13 +84,14 @@ const dds::xrce::ClientKey TCPServer::get_client_key(EndPoint* source)
 {
     dds::xrce::ClientKey client_key;
     TCPEndPoint* endpoint = static_cast<TCPEndPoint*>(source);
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = source_to_client_map_.find((uint64_t(endpoint->get_addr()) << 16) | endpoint->get_port());
     if (it != source_to_client_map_.end())
     {
-        client_key.at(0) = static_cast<uint8_t>(it->second & 0x000000FF);
-        client_key.at(1) = static_cast<uint8_t>((it->second & 0x0000FF00) >> 8);
-        client_key.at(2) = static_cast<uint8_t>((it->second & 0x00FF0000) >> 16);
-        client_key.at(3) = static_cast<uint8_t>((it->second & 0xFF000000) >> 24);
+        client_key.at(0) = uint8_t(it->second & 0x000000FF);
+        client_key.at(1) = uint8_t((it->second & 0x0000FF00) >> 8);
+        client_key.at(2) = uint8_t((it->second & 0x00FF0000) >> 16);
+        client_key.at(3) = uint8_t((it->second & 0xFF000000) >> 24);
     }
     else
     {
@@ -97,12 +104,12 @@ std::unique_ptr<EndPoint> TCPServer::get_source(const dds::xrce::ClientKey& clie
 {
     std::unique_ptr<EndPoint> source;
     uint32_t client_id = uint32_t(client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24));
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = client_to_source_map_.find(client_id);
     if (it != client_to_source_map_.end())
     {
         uint64_t source_id = it->second;
-        source.reset(new TCPEndPoint(static_cast<uint32_t>(source_id >> 16), 
-				     static_cast<uint16_t>(source_id & 0xFFFF)));
+        source.reset(new TCPEndPoint(uint32_t(source_id >> 16), uint16_t(source_id & 0xFFFF)));
     }
     return source;
 }
@@ -114,7 +121,10 @@ bool TCPServer::init()
     /* Socket initialization. */
     poll_fds_[0].fd = socket(PF_INET, SOCK_STREAM, 0);
 
-    if (INVALID_SOCKET != poll_fds_[0].fd)
+    /* Listener socket initialization. */
+    listener_poll_.fd = socket(PF_INET, SOCK_STREAM, 0);
+
+    if (INVALID_SOCKET != listener_poll_.fd)
     {
         /* IP and Port setup. */
         struct sockaddr_in address;
@@ -122,37 +132,28 @@ bool TCPServer::init()
         address.sin_port = htons(port_);
         address.sin_addr.s_addr = INADDR_ANY;
         memset(address.sin_zero, '\0', sizeof(address.sin_zero));
-        if (SOCKET_ERROR != bind(poll_fds_[0].fd, (struct sockaddr*)&address, sizeof(address)))
+        if (SOCKET_ERROR != bind(listener_poll_.fd, reinterpret_cast<struct sockaddr*>(&address), sizeof(address)))
         {
-            /* Listen Poll setup. */
-            poll_fds_[0].events = POLLIN;
+            /* Setup listener poll. */
+            listener_poll_.events = POLLIN;
 
-            /* Client polls setup. */
-            for (unsigned int i = 1; i < poll_fds_.size(); ++i)
+            /* Setup connections. */
+            for (size_t i = 0; i < poll_fds_.size(); ++i)
             {
                 poll_fds_[i].fd = INVALID_SOCKET;
                 poll_fds_[i].events = POLLIN;
+                connections_[i].poll_fd = &poll_fds_[i];
+                connections_[i].id = uint32_t(i);
+                connections_[i].active = false;
+                init_input_buffer(connections_[i].input_buffer);
+                free_connections_.push_back(connections_[i].id);
             }
 
-            /* Listener setup. */
-            if (SOCKET_ERROR != listen(poll_fds_[0].fd, TCP_MAX_BACKLOG_CONNECTIONS))
+            /* Init listener. */
+            if (SOCKET_ERROR != listen(listener_poll_.fd, TCP_MAX_BACKLOG_CONNECTIONS))
             {
-                /* Client setup. */
-                connections_[0].poll_fd = &poll_fds_[1];
-                connections_[0].id = 0;
-                init_input_buffer(&connections_[0].input_buffer);
-                for (unsigned int i = 1; i < poll_fds_.size() - 1; ++i)
-                {
-                    connections_[i].poll_fd = &poll_fds_[i + 1];
-                    init_input_buffer(&connections_[i].input_buffer);
-                    connections_[i - 1].next = &connections_[i];
-                    connections_[i].prev = &connections_[i - 1];
-                    connections_[i].id = static_cast<uint32_t>(i);
-                }
-                connections_.back().next = &connections_.front();
-                connections_.front().prev = &connections_.back();
-                free_connections_ = &connections_[0];
-                last_connection_read_ = free_connections_;
+                running_cond_ = true;
+                listener_thread_.reset(new std::thread(std::bind(&TCPServer::listener_loop, this)));
                 rv = true;
             }
         }
@@ -162,107 +163,43 @@ bool TCPServer::init()
 
 bool TCPServer::close()
 {
-    bool rv = false;
+    /* Stop listener thread. */
+    running_cond_ = false;
+    if (listener_thread_ && listener_thread_->joinable())
+    {
+        listener_thread_->join();
+    }
 
     /* Close listener. */
-    if (0 == closesocket(poll_fds_[0].fd))
+    if (INVALID_SOCKET != listener_poll_.fd)
     {
-        /* Disconnect clients. */
-        while (nullptr != active_connections_)
+        if (0 == closesocket(listener_poll_.fd))
         {
-            if (!disconnect_client(active_connections_))
-            {
-                break;
-            }
+            listener_poll_.fd = INVALID_SOCKET;
         }
-        rv = (nullptr == active_connections_);
     }
-    return rv;
+
+    /* Disconnect clients. */
+    for (auto& conn : connections_)
+    {
+        close_connection(conn);
+    }
+
+    std::lock_guard<std::mutex> lock(connections_mtx_);
+    return (INVALID_SOCKET == listener_poll_.fd) && (active_connections_.empty());
 }
 
 bool TCPServer::recv_message(InputPacket& input_packet, int timeout)
 {
-    bool rv = false;
-    int poll_rv = WSAPoll(poll_fds_.data(), static_cast<unsigned int>(poll_fds_.size()), timeout);
-    if (0 < poll_rv)
+    bool rv = true;
+    if (messages_queue_.empty() && !read_message(timeout))
     {
-        if (0 < (POLLIN & poll_fds_[0].revents) && nullptr != free_connections_)
-        {
-            /* New client connection. */
-            struct sockaddr client_addr;
-            int client_addr_len = sizeof(client_addr);
-            SOCKET incoming_fd = accept(poll_fds_[0].fd, &client_addr, &client_addr_len);
-            if (INVALID_SOCKET != incoming_fd)
-            {
-                /* Update available clients list. */
-                TCPConnection* incoming_connection = free_connections_;
-                incoming_connection->poll_fd->fd = incoming_fd;
-                incoming_connection->addr = reinterpret_cast<struct sockaddr_in*>(&client_addr)->sin_addr.s_addr;
-                incoming_connection->port = reinterpret_cast<struct sockaddr_in*>(&client_addr)->sin_port;
-                if (free_connections_ != free_connections_->next)
-                {
-                    free_connections_->prev->next = free_connections_->next;
-                    free_connections_->next->prev = free_connections_->prev;
-                    free_connections_ = free_connections_->next;
-                }
-                else
-                {
-                    free_connections_ = nullptr;
-                }
-
-                /* Update connected client list. */
-                if (nullptr != active_connections_)
-                {
-                    incoming_connection->prev = active_connections_->prev;
-                    incoming_connection->next = active_connections_;
-                    active_connections_->prev->next = incoming_connection;
-                    active_connections_->prev = incoming_connection;
-                }
-                else
-                {
-                    incoming_connection->prev = incoming_connection;
-                    incoming_connection->next = incoming_connection;
-                    active_connections_ = incoming_connection;
-                    last_connection_read_ = incoming_connection;
-                }
-                uint64_t source_id = (uint64_t(incoming_connection->addr) << 16) | incoming_connection->port;
-                source_to_connection_map_.insert(std::make_pair(source_id, incoming_connection->id));
-            }
-        }
-        else
-        {
-            if (nullptr != active_connections_)
-            {
-                /**
-                 * Receive Scheduler: the first client in attemp to read will be the neighbour of
-                 *                    the last client form which data was read.
-                 */
-                TCPConnection* base_connection = last_connection_read_->next;
-                TCPConnection* reader = last_connection_read_->next;
-                do
-                {
-                    if (0 < (POLLIN & reader->poll_fd->revents))
-                    {
-                        uint16_t bytes_read = read_data(reader);
-                        if (0 < bytes_read)
-                        {
-                            input_packet.message.reset(new InputMessage(reader->input_buffer.buffer.data(), bytes_read));
-                            last_connection_read_ = reader;
-                            input_packet.source.reset(new TCPEndPoint(reader->addr, reader->port));
-                            rv = true;
-                            break;
-                        }
-                    }
-                    reader = reader->next;
-
-                }
-                while (reader != base_connection);
-            }
-        }
+        rv = false;
     }
-    else if (0 == poll_rv)
+    else
     {
-        WSASetLastError(WAIT_TIMEOUT);
+        input_packet = std::move(messages_queue_.front());
+        messages_queue_.pop();
     }
     return rv;
 }
@@ -276,24 +213,26 @@ bool TCPServer::send_message(OutputPacket output_packet)
     const TCPEndPoint* destination = static_cast<const TCPEndPoint*>(output_packet.destination.get());
     uint64_t source_id = (uint64_t(destination->get_addr()) << 16) | destination->get_port();
 
+    std::unique_lock<std::mutex> lock(connections_mtx_);
     auto it = source_to_connection_map_.find(source_id);
     if (it != source_to_connection_map_.end())
     {
         TCPConnection& connection = connections_.at(it->second);
+        lock.unlock();
 
         /* Send message size. */
         msg_size_buf[0] = uint8_t(0x00FF & output_packet.message->get_len());
         msg_size_buf[1] = uint8_t((0xFF00 & output_packet.message->get_len()) >> 8);
         do
         {
-            send_rv = send(connection.poll_fd->fd, reinterpret_cast<char*>(msg_size_buf), 2, 0);
+            send_rv = send_locking(connection, reinterpret_cast<char*>(msg_size_buf), 2);
             if (SOCKET_ERROR != send_rv)
             {
                 bytes_sent += uint16_t(send_rv);
             }
             else
             {
-                disconnect_client(&connection);
+                close_connection(connection);
                 rv = false;
             }
         }
@@ -305,16 +244,16 @@ bool TCPServer::send_message(OutputPacket output_packet)
             bytes_sent = 0;
             do
             {
-                send_rv = send(connection.poll_fd->fd,
-                               reinterpret_cast<char*>(output_packet.message->get_buf() + bytes_sent),
-                               int(output_packet.message->get_len() - bytes_sent), 0);
+                send_rv = send_locking(connection,
+                                       reinterpret_cast<char*>(output_packet.message->get_buf() + bytes_sent),
+                                       int(output_packet.message->get_len() - bytes_sent));
                 if (SOCKET_ERROR != send_rv)
                 {
                     bytes_sent += uint16_t(send_rv);
                 }
                 else
                 {
-                    disconnect_client(&connection);
+                    close_connection(connection);
                     rv = false;
                 }
             }
@@ -330,7 +269,7 @@ int TCPServer::get_error()
     return WSAGetLastError();
 }
 
-uint16_t TCPServer::read_data(TCPConnection* connection)
+uint16_t TCPServer::read_data(TCPConnection& connection)
 {
     uint16_t rv = 0;
     bool exit_flag = false;
@@ -338,32 +277,28 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
     /* State Machine. */
     while(!exit_flag)
     {
-        switch (connection->input_buffer.state)
+        switch (connection.input_buffer.state)
         {
             case TCP_BUFFER_EMPTY:
             {
-                connection->input_buffer.position = 0;
+                connection.input_buffer.position = 0;
                 uint8_t size_buf[2];
-                int bytes_received = recv(connection->poll_fd->fd, reinterpret_cast<char*>(size_buf), 2, 0);
+                int bytes_received = recv_locking(connection, reinterpret_cast<char*>(size_buf), 2);
                 if (SOCKET_ERROR != bytes_received)
                 {
-                    connection->input_buffer.msg_size = 0;
+                    connection.input_buffer.msg_size = 0;
                     if (2 == bytes_received)
                     {
-                        connection->input_buffer.msg_size = uint16_t((uint16_t(size_buf[1]) << 8) | size_buf[0]);
-                        if (connection->input_buffer.msg_size != 0)
+                        connection.input_buffer.msg_size = uint16_t((uint16_t(size_buf[1]) << 8) | size_buf[0]);
+                        if (connection.input_buffer.msg_size != 0)
                         {
-                            connection->input_buffer.state = TCP_SIZE_READ;
-                        }
-                        else
-                        {
-                            connection->input_buffer.state = TCP_BUFFER_EMPTY;
+                            connection.input_buffer.state = TCP_SIZE_READ;
                         }
                     }
                     else
                     {
-                        connection->input_buffer.msg_size = uint16_t(size_buf[0]);
-                        connection->input_buffer.state = TCP_SIZE_INCOMPLETE;
+                        connection.input_buffer.msg_size = uint16_t(size_buf[0]);
+                        connection.input_buffer.state = TCP_SIZE_INCOMPLETE;
                     }
                 }
                 else
@@ -372,26 +307,25 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
                     {
                         WSASetLastError(WSAENOTCONN);
                     }
-                    disconnect_client(connection);
+                    close_connection(connection);
                     exit_flag = true;
                 }
-                exit_flag = (0 == WSAPoll(connection->poll_fd, 1, 0));
                 break;
             }
             case TCP_SIZE_INCOMPLETE:
             {
                 uint8_t size_msb;
-                int bytes_received = recv(connection->poll_fd->fd, reinterpret_cast<char*>(&size_msb), 1, 0);
+                int bytes_received = recv_locking(connection, reinterpret_cast<char*>(&size_msb), 1);
                 if (SOCKET_ERROR != bytes_received)
                 {
-                    connection->input_buffer.msg_size = uint16_t((uint16_t(size_msb) << 8) | connection->input_buffer.msg_size);
-                    if (connection->input_buffer.msg_size != 0)
+                    connection.input_buffer.msg_size = uint16_t((uint16_t(size_msb) << 8) | connection.input_buffer.msg_size);
+                    if (connection.input_buffer.msg_size != 0)
                     {
-                        connection->input_buffer.state = TCP_SIZE_READ;
+                        connection.input_buffer.state = TCP_SIZE_READ;
                     }
                     else
                     {
-                        connection->input_buffer.state = TCP_BUFFER_EMPTY;
+                        connection.input_buffer.state = TCP_BUFFER_EMPTY;
                     }
                 }
                 else
@@ -400,28 +334,28 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
                     {
                         WSASetLastError(WSAENOTCONN);
                     }
-                    disconnect_client(connection);
+                    close_connection(connection);
                     exit_flag = true;
                 }
-                exit_flag = (0 == WSAPoll(connection->poll_fd, 1, 0));
+                exit_flag = (0 == WSAPoll(connection.poll_fd, 1, 0));
                 break;
             }
             case TCP_SIZE_READ:
             {
-                connection->input_buffer.buffer.resize(connection->input_buffer.msg_size);
-                int bytes_received = recv(connection->poll_fd->fd,
-                                          reinterpret_cast<char*>(connection->input_buffer.buffer.data()),
-                                          static_cast<int>(connection->input_buffer.buffer.size()), 0);
+                connection.input_buffer.buffer.resize(connection.input_buffer.msg_size);
+                int bytes_received = recv_locking(connection,
+                                                  reinterpret_cast<char*>(connection.input_buffer.buffer.data()),
+                                                  int(connection.input_buffer.buffer.size()));
                 if (SOCKET_ERROR != bytes_received)
                 {
-                    if (uint16_t(bytes_received) == connection->input_buffer.msg_size)
+                    if (uint16_t(bytes_received) == connection.input_buffer.msg_size)
                     {
-                        connection->input_buffer.state = TCP_MESSAGE_AVAILABLE;
+                        connection.input_buffer.state = TCP_MESSAGE_AVAILABLE;
                     }
                     else
                     {
-                        connection->input_buffer.position = uint16_t(bytes_received);
-                        connection->input_buffer.state = TCP_MESSAGE_INCOMPLETE;
+                        connection.input_buffer.position = uint16_t(bytes_received);
+                        connection.input_buffer.state = TCP_MESSAGE_INCOMPLETE;
                         exit_flag = true;
                     }
                 }
@@ -431,24 +365,24 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
                     {
                         WSASetLastError(WSAENOTCONN);
                     }
-                    disconnect_client(connection);
+                    close_connection(connection);
                     exit_flag = true;
                 }
                 break;
             }
             case TCP_MESSAGE_INCOMPLETE:
             {
-                int bytes_received = recv(connection->poll_fd->fd,
-                                          reinterpret_cast<char*>(connection->input_buffer.buffer.data() +
-                                                                  connection->input_buffer.position),
-                                          static_cast<int>(connection->input_buffer.buffer.size() - 
-						           connection->input_buffer.position), 0);
+                int bytes_received = recv_locking(connection,
+                                                  reinterpret_cast<char*>(connection.input_buffer.buffer.data() +
+                                                                          connection.input_buffer.position),
+                                                  int(connection.input_buffer.buffer.size() - 
+                                                      connection.input_buffer.position));
                 if (SOCKET_ERROR != bytes_received)
                 {
-                    connection->input_buffer.position += uint16_t(bytes_received);
-                    if (connection->input_buffer.position == connection->input_buffer.msg_size)
+                    connection.input_buffer.position += uint16_t(bytes_received);
+                    if (connection.input_buffer.position == connection.input_buffer.msg_size)
                     {
-                        connection->input_buffer.state = TCP_MESSAGE_AVAILABLE;
+                        connection.input_buffer.state = TCP_MESSAGE_AVAILABLE;
                     }
                     else
                     {
@@ -461,15 +395,15 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
                     {
                         WSASetLastError(WSAENOTCONN);
                     }
-                    disconnect_client(connection);
+                    close_connection(connection);
                     exit_flag = true;
                 }
                 break;
             }
             case TCP_MESSAGE_AVAILABLE:
             {
-                rv = connection->input_buffer.msg_size;
-                connection->input_buffer.state = TCP_BUFFER_EMPTY;
+                rv = connection.input_buffer.msg_size;
+                connection.input_buffer.state = TCP_BUFFER_EMPTY;
                 exit_flag = true;
                 break;
             }
@@ -479,63 +413,156 @@ uint16_t TCPServer::read_data(TCPConnection* connection)
     return rv;
 }
 
-bool TCPServer::disconnect_client(TCPConnection* connection)
+bool TCPServer::open_connection(SOCKET fd, struct sockaddr_in* sockaddr)
 {
     bool rv = false;
-    if (0 == closesocket(connection->poll_fd->fd))
+    std::lock_guard<std::mutex> lock(connections_mtx_);
+    if (!free_connections_.empty())
     {
-        if (nullptr != free_connections_)
-        {
-            if (connection != connection->next)
-            {
-                /* Remove from connected_clients_. */
-                connection->prev->next = connection->next;
-                connection->next->prev = connection->prev;
-            }
-            else
-            {
-                active_connections_ = nullptr;
-            }
+        uint32_t id = free_connections_.front();
+        TCPConnection& connection = connections_[id];
+        connection.poll_fd->fd = fd;
+        connection.addr = sockaddr->sin_addr.s_addr;
+        connection.port = sockaddr->sin_port;
+        connection.active = true;
 
-            /* Add to free connections. */
-            connection->next = free_connections_;
-            connection->prev = free_connections_->prev;
-            free_connections_->prev->next = connection;
-            free_connections_->prev = connection;
-
-            /* Reset last connection read if necessary. */
-            if (connection == last_connection_read_)
-            {
-                last_connection_read_ = active_connections_;
-            }
-        }
-        else
-        {
-            connection->next = connection;
-            connection->prev = connection;
-            free_connections_ = connection;
-        }
-        connection->poll_fd->fd = INVALID_SOCKET;
-
-        /* Free connection maps. */
-        uint64_t source_id = (uint64_t(connection->addr) << 16) | connection->port;
-        auto it = source_to_client_map_.find(source_id);
-        if (it != source_to_client_map_.end())
-        {
-            source_to_connection_map_.erase(it->first);
-            client_to_source_map_.erase(it->second);
-            source_to_client_map_.erase(it->first);
-        }
+        uint64_t source_id = (uint64_t(connection.addr) << 16) | connection.port;
+        source_to_connection_map_[source_id] = connection.id;
+        active_connections_.insert(id);
+        free_connections_.pop_front();
         rv = true;
     }
     return rv;
 }
 
-void TCPServer::init_input_buffer(TCPInputBuffer* buffer)
+bool TCPServer::close_connection(TCPConnection& connection)
 {
-    buffer->state = TCP_BUFFER_EMPTY;
-    buffer->msg_size = 0;
+    bool rv = false;
+    std::unique_lock<std::mutex> lock(connections_mtx_);
+    auto it_conn = active_connections_.find(connection.id);
+    if (it_conn != active_connections_.end())
+    {
+        lock.unlock();
+        /* Add lock for close. */
+        std::unique_lock<std::mutex> conn_lock(connection.mtx);
+        if (0 == closesocket(connection.poll_fd->fd))
+        {
+            connection.poll_fd->fd = INVALID_SOCKET;
+            connection.active = false;
+            conn_lock.unlock();
+
+            uint64_t source_id = (uint64_t(connection.addr) << 16) | connection.port;
+            /* Clear connections map and lists. */
+            lock.lock();
+            source_to_connection_map_.erase(source_id);
+            active_connections_.erase(it_conn);
+            free_connections_.push_back(connection.id);
+            lock.unlock();
+
+            std::unique_lock<std::mutex> client_lock(clients_mtx_);
+            auto it_client = source_to_client_map_.find(source_id);
+            if (it_client != source_to_client_map_.end())
+            {
+                client_to_source_map_.erase(it_client->second);
+                source_to_client_map_.erase(it_client->first);
+            }
+            rv = true;
+        }
+    }
+    return rv;
 }
 
-} // namespace uxr 
+void TCPServer::init_input_buffer(TCPInputBuffer& buffer)
+{
+    buffer.state = TCP_BUFFER_EMPTY;
+    buffer.msg_size = 0;
+}
+
+bool TCPServer::read_message(int timeout)
+{
+    bool rv = false;
+    int poll_rv = WSAPoll(poll_fds_.data(), ULONG(poll_fds_.size()), timeout);
+    if (0 < poll_rv)
+    {
+        for (auto& conn : connections_)
+        {
+            if (0 < (POLLIN & conn.poll_fd->revents))
+            {
+                uint16_t bytes_read = read_data(conn);
+                if (0 < bytes_read)
+                {
+                    InputPacket input_packet;
+                    input_packet.message.reset(new InputMessage(conn.input_buffer.buffer.data(), bytes_read));
+                    input_packet.source.reset(new TCPEndPoint(conn.addr, conn.port));
+                    messages_queue_.push(std::move(input_packet));
+                    rv = true;
+                }
+            }
+        }
+    }
+    else
+    {
+        if (0 == poll_rv)
+        {
+            WSASetLastError(WAIT_TIMEOUT);
+        }
+    }
+    return rv;
+}
+
+void TCPServer::listener_loop()
+{
+    while (running_cond_)
+    {
+        int poll_rv = WSAPoll(&listener_poll_, 1, 100);
+        if (0 < poll_rv)
+        {
+            if (0 < (POLLIN & listener_poll_.revents))
+            {
+                if (connection_available())
+                {
+                    /* New client connection. */
+                    struct sockaddr client_addr;
+                    int client_addr_len = sizeof(client_addr);
+                    SOCKET incoming_fd = accept(listener_poll_.fd, &client_addr, &client_addr_len);
+                    if (INVALID_SOCKET != incoming_fd)
+                    {
+                        /* Open connection. */
+                        open_connection(incoming_fd, reinterpret_cast<struct sockaddr_in*>(&client_addr));
+                    }
+                }
+            }
+        }
+    }
+}
+
+bool TCPServer::connection_available()
+{
+    std::lock_guard<std::mutex> lock(connections_mtx_);
+    return !free_connections_.empty();
+}
+
+int TCPServer::recv_locking(TCPConnection& connection, char* buffer, int len)
+{
+    int rv = 0;
+    std::lock_guard<std::mutex> lock(connection.mtx);
+    if (connection.active)
+    {
+        rv = recv(connection.poll_fd->fd, buffer, len, 0);
+    }
+    return rv;
+}
+
+int TCPServer::send_locking(TCPConnection& connection, char* buffer, int len)
+{
+    int rv = 0;
+    std::lock_guard<std::mutex> lock(connection.mtx);
+    if (connection.active)
+    {
+        rv = send(connection.poll_fd->fd, buffer, len, 0);
+    }
+    return rv;
+}
+
+} // namespace uxr
 } // namespace eprosima

--- a/src/cpp/transport/UDPServerLinux.cpp
+++ b/src/cpp/transport/UDPServerLinux.cpp
@@ -36,10 +36,11 @@ UDPServer::UDPServer(uint16_t port)
 void UDPServer::on_create_client(EndPoint* source, const dds::xrce::ClientKey& client_key)
 {
     UDPEndPoint* endpoint = static_cast<UDPEndPoint*>(source);
-    uint64_t source_id = ((uint64_t)endpoint->get_addr() << 16) | endpoint->get_port();
-    uint32_t client_id = client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24);
+    uint64_t source_id = (uint64_t(endpoint->get_addr()) << 16) | endpoint->get_port();
+    uint32_t client_id = uint32_t(client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) << 24));
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it_client = client_to_source_map_.find(client_id);
     if (it_client != client_to_source_map_.end())
     {
@@ -68,6 +69,7 @@ void UDPServer::on_delete_client(EndPoint* source)
     uint64_t source_id = (endpoint->get_addr() << 16) | endpoint->get_port();
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = source_to_client_map_.find(source_id);
     if (it != source_to_client_map_.end())
     {
@@ -80,13 +82,14 @@ const dds::xrce::ClientKey UDPServer::get_client_key(EndPoint* source)
 {
     dds::xrce::ClientKey client_key;
     UDPEndPoint* endpoint = static_cast<UDPEndPoint*>(source);
-    auto it = source_to_client_map_.find(((uint64_t)endpoint->get_addr() << 16) | endpoint->get_port());
+    std::lock_guard<std::mutex> lock(clients_mtx_);
+    auto it = source_to_client_map_.find((uint64_t(endpoint->get_addr()) << 16) | endpoint->get_port());
     if (it != source_to_client_map_.end())
     {
-        client_key.at(0) = it->second & 0x000000FF;
-        client_key.at(1) = (it->second & 0x0000FF00) >> 8;
-        client_key.at(2) = (it->second & 0x00FF0000) >> 16;
-        client_key.at(3) = (it->second & 0xFF000000) >> 24;
+        client_key.at(0) = uint8_t(it->second & 0x000000FF);
+        client_key.at(1) = uint8_t((it->second & 0x0000FF00) >> 8);
+        client_key.at(2) = uint8_t((it->second & 0x00FF0000) >> 16);
+        client_key.at(3) = uint8_t((it->second & 0xFF000000) >> 24);
     }
     else
     {
@@ -98,12 +101,13 @@ const dds::xrce::ClientKey UDPServer::get_client_key(EndPoint* source)
 std::unique_ptr<EndPoint> UDPServer::get_source(const dds::xrce::ClientKey& client_key)
 {
     std::unique_ptr<EndPoint> source;
-    uint32_t client_id = client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24);
+    uint32_t client_id = uint32_t(client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24));
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = client_to_source_map_.find(client_id);
     if (it != client_to_source_map_.end())
     {
         uint64_t source_id = it->second;
-        source.reset(new UDPEndPoint(source_id >> 16, source_id & 0xFFFF));
+        source.reset(new UDPEndPoint(uint32_t(source_id >> 16), uint16_t(source_id & 0xFFFF)));
     }
     return source;
 }

--- a/src/cpp/transport/UDPServerWindows.cpp
+++ b/src/cpp/transport/UDPServerWindows.cpp
@@ -33,6 +33,7 @@ void UDPServer::on_create_client(EndPoint* source, const dds::xrce::ClientKey& c
     uint32_t client_id = uint32_t(client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24));
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it_client = client_to_source_map_.find(client_id);
     if (it_client != client_to_source_map_.end())
     {
@@ -61,6 +62,7 @@ void UDPServer::on_delete_client(EndPoint* source)
     uint64_t source_id = (endpoint->get_addr() << 16) | endpoint->get_port();
 
     /* Update maps. */
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = source_to_client_map_.find(source_id);
     if (it != source_to_client_map_.end())
     {
@@ -73,6 +75,7 @@ const dds::xrce::ClientKey UDPServer::get_client_key(EndPoint* source)
 {
     dds::xrce::ClientKey client_key;
     UDPEndPoint* endpoint = static_cast<UDPEndPoint*>(source);
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = source_to_client_map_.find((uint64_t(endpoint->get_addr()) << 16) | endpoint->get_port());
     if (it != source_to_client_map_.end())
     {
@@ -92,6 +95,7 @@ std::unique_ptr<EndPoint> UDPServer::get_source(const dds::xrce::ClientKey& clie
 {
     std::unique_ptr<EndPoint> source;
     uint32_t client_id = uint32_t(client_key.at(0) + (client_key.at(1) << 8) + (client_key.at(2) << 16) + (client_key.at(3) <<24));
+    std::lock_guard<std::mutex> lock(clients_mtx_);
     auto it = client_to_source_map_.find(client_id);
     if (it != client_to_source_map_.end())
     {


### PR DESCRIPTION
This pull request provide the following improvements:

- First, concurrence error was solved in the TCP server. This error took place when the reader thread closed the socket while the sender was trying to send data and vice-versa.
- Second, Windows transports (UDP/TCP) have been stabilized in both Agent and Client.