### PR TITLE
Refs #3846. Added discovery flag to the agent.

### DIFF
--- a/include/uxr/agent/transport/Server.hpp
+++ b/include/uxr/agent/transport/Server.hpp
@@ -33,7 +33,7 @@ public:
     Server();
     virtual ~Server();
 
-    microxrcedds_agent_DllAPI bool run();
+    microxrcedds_agent_DllAPI bool run(bool discovery_enabled = false);
     microxrcedds_agent_DllAPI bool stop();
 
     void push_output_packet(OutputPacket output_packet);
@@ -43,7 +43,7 @@ public:
     virtual std::unique_ptr<EndPoint> get_source(const dds::xrce::ClientKey& client_key) = 0;
 
 private:
-    virtual bool init() = 0;
+    virtual bool init(bool discovery_enabled) = 0;
     virtual bool close() = 0;
     virtual bool recv_message(InputPacket& input_packet, int timeout) = 0;
     virtual bool send_message(OutputPacket output_packet) = 0;

--- a/include/uxr/agent/transport/serial/SerialServerLinux.hpp
+++ b/include/uxr/agent/transport/serial/SerialServerLinux.hpp
@@ -31,7 +31,7 @@ public:
     ~SerialServer() = default;
 
 private:
-    bool init() override;
+    bool init(bool discovery_enabled) override;
     bool close() override;
     bool recv_message(InputPacket& input_packet, int timeout) override;
     bool send_message(OutputPacket output_packet) override;

--- a/include/uxr/agent/transport/serial/SerialServerLinux.hpp
+++ b/include/uxr/agent/transport/serial/SerialServerLinux.hpp
@@ -31,11 +31,12 @@ public:
     ~SerialServer() = default;
 
 private:
-    bool init(bool discovery_enabled) override;
-    bool close() override;
-    bool recv_message(InputPacket& input_packet, int timeout) override;
-    bool send_message(OutputPacket output_packet) override;
-    int get_error() override;
+    bool init(bool discovery_enabled) final;
+    bool close() final;
+    bool recv_message(InputPacket& input_packet, int timeout) final;
+    bool send_message(OutputPacket output_packet) final;
+    int get_error() final;
+
     static size_t write_data(void* instance, uint8_t* buf, size_t len);
     static size_t read_data(void* instance, uint8_t* buf, size_t len, int timeout);
 

--- a/include/uxr/agent/transport/tcp/TCPServerLinux.hpp
+++ b/include/uxr/agent/transport/tcp/TCPServerLinux.hpp
@@ -44,7 +44,7 @@ public:
     ~TCPServer() = default;
 
 private:
-    virtual bool init() override;
+    virtual bool init(bool discovery_enabled) override;
     virtual bool close() override;
     virtual bool recv_message(InputPacket& input_packet, int timeout) override;
     virtual bool send_message(OutputPacket output_packet) override;

--- a/include/uxr/agent/transport/tcp/TCPServerLinux.hpp
+++ b/include/uxr/agent/transport/tcp/TCPServerLinux.hpp
@@ -44,11 +44,11 @@ public:
     ~TCPServer() = default;
 
 private:
-    virtual bool init(bool discovery_enabled) override;
-    virtual bool close() override;
-    virtual bool recv_message(InputPacket& input_packet, int timeout) override;
-    virtual bool send_message(OutputPacket output_packet) override;
-    virtual int get_error() override;
+    bool init(bool discovery_enabled) final;
+    bool close() final;
+    bool recv_message(InputPacket& input_packet, int timeout) final;
+    bool send_message(OutputPacket output_packet) final;
+    int get_error() final;
     bool read_message(int timeout);
     bool open_connection(int fd, struct sockaddr_in* sockaddr);
     bool connection_available();

--- a/include/uxr/agent/transport/tcp/TCPServerWindows.hpp
+++ b/include/uxr/agent/transport/tcp/TCPServerWindows.hpp
@@ -39,11 +39,11 @@ public:
 class TCPServer : public TCPServerBase
 {
 public:
-    microxrcedds_agent_DllAPI TCPServer(uint16_t port);
+    microxrcedds_agent_DllAPI TCPServer(uint16_t port, uint16_t discovery_port);
     microxrcedds_agent_DllAPI ~TCPServer() = default;
 
 private:
-    virtual bool init() override;
+    virtual bool init(bool discovery_enabled) override;
     virtual bool close() override;
     virtual bool recv_message(InputPacket& input_packet, int timeout) override;
     virtual bool send_message(OutputPacket output_packet) override;

--- a/include/uxr/agent/transport/tcp/TCPServerWindows.hpp
+++ b/include/uxr/agent/transport/tcp/TCPServerWindows.hpp
@@ -43,11 +43,11 @@ public:
     microxrcedds_agent_DllAPI ~TCPServer() = default;
 
 private:
-    virtual bool init(bool discovery_enabled) override;
-    virtual bool close() override;
-    virtual bool recv_message(InputPacket& input_packet, int timeout) override;
-    virtual bool send_message(OutputPacket output_packet) override;
-    virtual int get_error() override;
+    bool init(bool discovery_enabled) final;
+    bool close() final;
+    bool recv_message(InputPacket& input_packet, int timeout) final;
+    bool send_message(OutputPacket output_packet) final;
+    int get_error() final;
     bool read_message(int timeout);
     bool open_connection(SOCKET fd, struct sockaddr_in* sockaddr);
     bool connection_available();

--- a/include/uxr/agent/transport/tcp/TCPServerWindows.hpp
+++ b/include/uxr/agent/transport/tcp/TCPServerWindows.hpp
@@ -39,7 +39,7 @@ public:
 class TCPServer : public TCPServerBase
 {
 public:
-    microxrcedds_agent_DllAPI TCPServer(uint16_t port, uint16_t discovery_port);
+    microxrcedds_agent_DllAPI TCPServer(uint16_t port, uint16_t discovery_port = 0);
     microxrcedds_agent_DllAPI ~TCPServer() = default;
 
 private:

--- a/include/uxr/agent/transport/udp/UDPServerLinux.hpp
+++ b/include/uxr/agent/transport/udp/UDPServerLinux.hpp
@@ -34,7 +34,7 @@ public:
     ~UDPServer() = default;
 
 private:
-    virtual bool init() override;
+    virtual bool init(bool discovery_enabled) override;
     virtual bool close() override;
     virtual bool recv_message(InputPacket& input_packet, int timeout) override;
     virtual bool send_message(OutputPacket output_packet) override;

--- a/include/uxr/agent/transport/udp/UDPServerLinux.hpp
+++ b/include/uxr/agent/transport/udp/UDPServerLinux.hpp
@@ -34,11 +34,11 @@ public:
     ~UDPServer() = default;
 
 private:
-    virtual bool init(bool discovery_enabled) override;
-    virtual bool close() override;
-    virtual bool recv_message(InputPacket& input_packet, int timeout) override;
-    virtual bool send_message(OutputPacket output_packet) override;
-    virtual int get_error() override;
+    bool init(bool discovery_enabled) final;
+    bool close() final;
+    bool recv_message(InputPacket& input_packet, int timeout) final;
+    bool send_message(OutputPacket output_packet) final;
+    int get_error() final;
 
 private:
     struct pollfd poll_fd_;

--- a/include/uxr/agent/transport/udp/UDPServerWindows.hpp
+++ b/include/uxr/agent/transport/udp/UDPServerWindows.hpp
@@ -32,11 +32,11 @@ public:
     microxrcedds_agent_DllAPI ~UDPServer() = default;
 
 private:
-    virtual bool init(bool discovery_enabled) override;
-    virtual bool close() override;
-    virtual bool recv_message(InputPacket& input_packet, int timeout) override;
-    virtual bool send_message(OutputPacket output_packet) override;
-    virtual int get_error() override;
+    bool init(bool discovery_enabled) final;
+    bool close() final;
+    bool recv_message(InputPacket& input_packet, int timeout) final;
+    bool send_message(OutputPacket output_packet) final;
+    int get_error() final;
 
 private:
     WSAPOLLFD poll_fd_;

--- a/include/uxr/agent/transport/udp/UDPServerWindows.hpp
+++ b/include/uxr/agent/transport/udp/UDPServerWindows.hpp
@@ -28,11 +28,11 @@ namespace uxr {
 class UDPServer : public UDPServerBase
 {
 public:
-    microxrcedds_agent_DllAPI UDPServer(uint16_t port);
+    microxrcedds_agent_DllAPI UDPServer(uint16_t port, uint16_t discovery_port);
     microxrcedds_agent_DllAPI ~UDPServer() = default;
 
 private:
-    virtual bool init() override;
+    virtual bool init(bool discovery_enabled) override;
     virtual bool close() override;
     virtual bool recv_message(InputPacket& input_packet, int timeout) override;
     virtual bool send_message(OutputPacket output_packet) override;

--- a/include/uxr/agent/transport/udp/UDPServerWindows.hpp
+++ b/include/uxr/agent/transport/udp/UDPServerWindows.hpp
@@ -28,7 +28,7 @@ namespace uxr {
 class UDPServer : public UDPServerBase
 {
 public:
-    microxrcedds_agent_DllAPI UDPServer(uint16_t port, uint16_t discovery_port);
+    microxrcedds_agent_DllAPI UDPServer(uint16_t port, uint16_t discovery_port = 0);
     microxrcedds_agent_DllAPI ~UDPServer() = default;
 
 private:

--- a/microxrce_agent.cpp
+++ b/microxrce_agent.cpp
@@ -22,6 +22,7 @@
 #include <termios.h>
 #include <fcntl.h>
 #endif //_WIN32
+
 #include <iostream>
 #include <string>
 #include <sstream>
@@ -38,8 +39,8 @@ void showHelp()
 #else
     std::cout << "    serial <device_name>" << std::endl;
     std::cout << "    pseudo-serial" << std::endl;
-    std::cout << "    udp <local_port> [<discovery_port>] [--discovery]" << std::endl;
-    std::cout << "    tcp <local_port> [<discovery_port>] [--discovery]" << std::endl;
+    std::cout << "    udp <local_port> [--discovery [<discovery_port>] ]" << std::endl;
+    std::cout << "    tcp <local_port> [--discovery [<discovery_port>] ]" << std::endl;
 #endif
 }
 
@@ -105,36 +106,44 @@ int main(int argc, char** argv)
         std::cout << "UDP agent initialization... ";
         uint16_t port = parsePort(cl[1]);
 
-        server = 3 <= cl.size() && '-' != cl[2][0] //discovery port
-                 ? new eprosima::uxr::UDPServer(port, parsePort(cl[2]))
-                 : new eprosima::uxr::UDPServer(port);
-
+#ifndef _WIN32
         if(3 <= cl.size())
         {
-            discovery_flag = "--discovery" == (4 == cl.size() ?  cl[3] : cl[2]);
-            if(('-' == cl[2][0] || (4 == cl.size() && '-' == cl[3][0])) && !discovery_flag)
+            discovery_flag = "--discovery" == cl[2];
+            if(!discovery_flag)
             {
                 initializationError();
             }
         }
+
+        server = 4 <= cl.size()
+                 ? new eprosima::uxr::UDPServer(port, parsePort(cl[3]))
+                 : new eprosima::uxr::UDPServer(port);
+#else
+        server = new eprosima::uxr::UDPServer(port);
+#endif
     }
     else if((2 <= cl.size()) && ("tcp" == cl[0]))
     {
         std::cout << "TCP agent initialization... ";
         uint16_t port = parsePort(cl[1]);
 
-        server = 3 <= cl.size() && '-' != cl[2][0] //discovery port
-                 ? new eprosima::uxr::TCPServer(port, parsePort(cl[2]))
-                 : new eprosima::uxr::TCPServer(port);
-
+#ifndef _WIN32
         if(3 <= cl.size())
         {
-            discovery_flag = "--discovery" == (4 == cl.size() ?  cl[3] : cl[2]);
-            if(('-' == cl[2][0] || (4 == cl.size() && '-' == cl[3][0])) && !discovery_flag)
+            discovery_flag = "--discovery" == cl[2];
+            if(!discovery_flag)
             {
                 initializationError();
             }
         }
+
+        server = 4 <= cl.size()
+                 ? new eprosima::uxr::TCPServer(port, parsePort(cl[3]))
+                 : new eprosima::uxr::TCPServer(port);
+#else
+        server = new eprosima::uxr::TCPServer(port);
+#endif
     }
 #ifndef _WIN32
     else if((2 == cl.size()) && ("serial" == cl[0]))

--- a/microxrce_agent.cpp
+++ b/microxrce_agent.cpp
@@ -38,8 +38,8 @@ void showHelp()
 #else
     std::cout << "    serial <device_name>" << std::endl;
     std::cout << "    pseudo-serial" << std::endl;
-    std::cout << "    udp <local_port> [<discovery_port>]" << std::endl;
-    std::cout << "    tcp <local_port> [<discovery_port>]" << std::endl;
+    std::cout << "    udp <local_port> [<discovery_port>] [--discovery]" << std::endl;
+    std::cout << "    tcp <local_port> [<discovery_port>] [--discovery]" << std::endl;
 #endif
 }
 
@@ -74,6 +74,7 @@ int main(int argc, char** argv)
 {
     eprosima::uxr::Server* server = nullptr;
     std::vector<std::string> cl(0);
+    bool discovery_flag = false;
 
     if (1 == argc)
     {
@@ -103,25 +104,37 @@ int main(int argc, char** argv)
     {
         std::cout << "UDP agent initialization... ";
         uint16_t port = parsePort(cl[1]);
-#ifdef _WIN32
-        server = new eprosima::uxr::UDPServer(port);
-#else
-        server = (3 == cl.size()) //discovery port
+
+        server = 3 <= cl.size() && '-' != cl[2][0] //discovery port
                  ? new eprosima::uxr::UDPServer(port, parsePort(cl[2]))
                  : new eprosima::uxr::UDPServer(port);
-#endif
+
+        if(3 <= cl.size())
+        {
+            discovery_flag = "--discovery" == (4 == cl.size() ?  cl[3] : cl[2]);
+            if(('-' == cl[2][0] || (4 == cl.size() && '-' == cl[3][0])) && !discovery_flag)
+            {
+                initializationError();
+            }
+        }
     }
     else if((2 <= cl.size()) && ("tcp" == cl[0]))
     {
         std::cout << "TCP agent initialization... ";
         uint16_t port = parsePort(cl[1]);
-#ifdef _WIN32
-        server = new eprosima::uxr::TCPServer(port);
-#else
-        server = (3 == cl.size()) //discovery port
+
+        server = 3 <= cl.size() && '-' != cl[2][0] //discovery port
                  ? new eprosima::uxr::TCPServer(port, parsePort(cl[2]))
                  : new eprosima::uxr::TCPServer(port);
-#endif
+
+        if(3 <= cl.size())
+        {
+            discovery_flag = "--discovery" == (4 == cl.size() ?  cl[3] : cl[2]);
+            if(('-' == cl[2][0] || (4 == cl.size() && '-' == cl[3][0])) && !discovery_flag)
+            {
+                initializationError();
+            }
+        }
     }
 #ifndef _WIN32
     else if((2 == cl.size()) && ("serial" == cl[0]))
@@ -211,7 +224,7 @@ int main(int argc, char** argv)
     if (nullptr != server)
     {
         /* Launch server. */
-        if (server->run())
+        if (server->run(discovery_flag))
         {
             std::cout << "OK" << std::endl;
             std::cin.clear();

--- a/src/cpp/transport/Server.cpp
+++ b/src/cpp/transport/Server.cpp
@@ -32,9 +32,9 @@ Server::~Server()
     delete processor_;
 }
 
-bool Server::run()
+bool Server::run(bool discovery_enabled)
 {
-    if (!init())
+    if (!init(discovery_enabled))
     {
         return false;
     }

--- a/src/cpp/transport/serial/SerialServerLinux.cpp
+++ b/src/cpp/transport/serial/SerialServerLinux.cpp
@@ -28,8 +28,10 @@ SerialServer::SerialServer(int fd, uint8_t addr)
     poll_fd_.fd = fd;
 }
 
-bool SerialServer::init()
+bool SerialServer::init(bool discovery_enabled)
 {
+    (void) discovery_enabled;
+
     /* Init serial IO. */
     uxr_init_serial_io(&serial_io_, addr_);
 

--- a/src/cpp/transport/tcp/TCPServerLinux.cpp
+++ b/src/cpp/transport/tcp/TCPServerLinux.cpp
@@ -41,13 +41,16 @@ TCPServer::TCPServer(uint16_t port, uint16_t discovery_port)
       discovery_server_(*processor_, port_, discovery_port)
 {}
 
-bool TCPServer::init()
+bool TCPServer::init(bool discovery_enabled)
 {
     bool rv = false;
 
-    if (!discovery_server_.run())
+    if (discovery_enabled)
     {
-        return false;
+        if (!discovery_server_.run())
+        {
+            return false;
+        }
     }
 
     /* Ignore SIGPIPE signal. */

--- a/src/cpp/transport/tcp/TCPServerWindows.cpp
+++ b/src/cpp/transport/tcp/TCPServerWindows.cpp
@@ -20,7 +20,7 @@ namespace uxr {
 
 const uint8_t max_attemps = 16;
 
-TCPServer::TCPServer(uint16_t port)
+TCPServer::TCPServer(uint16_t port, uint16_t discovery_port)
     : TCPServerBase(port),
       connections_{},
       active_connections_(),
@@ -31,10 +31,14 @@ TCPServer::TCPServer(uint16_t port)
       listener_thread_(),
       running_cond_(false),
       messages_queue_{}
-{}
-
-bool TCPServer::init()
 {
+    (void) discovery_port;
+}
+
+bool TCPServer::init(bool discovery_enabled)
+{
+    (void) discovery_enabled;
+
     bool rv = false;
 
     /* Socket initialization. */

--- a/src/cpp/transport/udp/UDPServerLinux.cpp
+++ b/src/cpp/transport/udp/UDPServerLinux.cpp
@@ -32,14 +32,17 @@ UDPServer::UDPServer(uint16_t port, uint16_t discovery_port)
       discovery_server_(*processor_, port_, discovery_port)
 {}
 
-bool UDPServer::init()
+bool UDPServer::init(bool discovery_enabled)
 {
     bool rv = false;
 
     /* Init discovery. */
-    if (!discovery_server_.run())
+    if (discovery_enabled)
     {
-        return false;
+        if (!discovery_server_.run())
+        {
+            return false;
+        }
     }
 
     /* Socker initialization. */

--- a/src/cpp/transport/udp/UDPServerWindows.cpp
+++ b/src/cpp/transport/udp/UDPServerWindows.cpp
@@ -18,14 +18,18 @@
 namespace eprosima {
 namespace uxr {
 
-UDPServer::UDPServer(uint16_t port)
+UDPServer::UDPServer(uint16_t port, uint16_t discovery_port)
     : UDPServerBase(port),
       poll_fd_{},
       buffer_{0}
-{}
-
-bool UDPServer::init()
 {
+    (void) discovery_port;
+}
+
+bool UDPServer::init(bool discovery_enabled)
+{
+    (void) discovery_enabled;
+
     bool rv = false;
 
     /* Socker initialization. */


### PR DESCRIPTION
- Discovery disables by default.
- New flag `--discovery` to enable the discovery system.
- Transports `UDPServer` and `TCPServer` with the same API in Linux and Windows.