### PR TITLE
Change create session behaviour

### DIFF
--- a/include/uxr/agent/transport/Server.hpp
+++ b/include/uxr/agent/transport/Server.hpp
@@ -37,7 +37,7 @@ public:
     microxrcedds_agent_DllAPI bool stop();
 
     void push_output_packet(OutputPacket output_packet);
-    virtual void on_create_client(EndPoint* source, const dds::xrce::ClientKey& client_key) = 0;
+    virtual void on_create_client(EndPoint* source, const dds::xrce::CLIENT_Representation& representation) = 0;
     virtual void on_delete_client(EndPoint* source) = 0;
     virtual const dds::xrce::ClientKey get_client_key(EndPoint* source) = 0;
     virtual std::unique_ptr<EndPoint> get_source(const dds::xrce::ClientKey& client_key) = 0;

--- a/include/uxr/agent/transport/serial/SerialServerBase.hpp
+++ b/include/uxr/agent/transport/serial/SerialServerBase.hpp
@@ -31,7 +31,7 @@ public:
     SerialServerBase(uint8_t addr);
     ~SerialServerBase() = default;
 
-    void on_create_client(EndPoint* source, const dds::xrce::ClientKey& client_key) override;
+    void on_create_client(EndPoint* source, const dds::xrce::CLIENT_Representation& representation) override;
     void on_delete_client(EndPoint* source) override;
     const dds::xrce::ClientKey get_client_key(EndPoint* source) override;
     std::unique_ptr<EndPoint> get_source(const dds::xrce::ClientKey& client_key) override;

--- a/include/uxr/agent/transport/tcp/TCPServerBase.hpp
+++ b/include/uxr/agent/transport/tcp/TCPServerBase.hpp
@@ -31,7 +31,7 @@ public:
     TCPServerBase(uint16_t port);
     ~TCPServerBase() = default;
 
-    void on_create_client(EndPoint* source, const dds::xrce::ClientKey& client_key) override;
+    void on_create_client(EndPoint* source, const dds::xrce::CLIENT_Representation& representation) override;
     void on_delete_client(EndPoint* source) override;
     const dds::xrce::ClientKey get_client_key(EndPoint *source) override;
     std::unique_ptr<EndPoint> get_source(const dds::xrce::ClientKey& client_key) override;

--- a/include/uxr/agent/transport/udp/UDPServerBase.hpp
+++ b/include/uxr/agent/transport/udp/UDPServerBase.hpp
@@ -29,10 +29,10 @@ public:
     UDPServerBase(uint16_t port);
     ~UDPServerBase() = default;
 
-    virtual void on_create_client(EndPoint* source, const dds::xrce::ClientKey& client_key) override;
-    virtual void on_delete_client(EndPoint* source) override;
-    virtual const dds::xrce::ClientKey get_client_key(EndPoint* source) override;
-    virtual std::unique_ptr<EndPoint> get_source(const dds::xrce::ClientKey& client_key) override;
+    void on_create_client(EndPoint* source, const dds::xrce::CLIENT_Representation& representation) override;
+    void on_delete_client(EndPoint* source) override;
+    const dds::xrce::ClientKey get_client_key(EndPoint* source) override;
+    std::unique_ptr<EndPoint> get_source(const dds::xrce::ClientKey& client_key) override;
 
 protected:
     uint16_t port_;


### PR DESCRIPTION
This pull request changed the create session behaviour.
Now when a Client, in _no-client-key mode_, tries to create a session with different `ClientKey` but the same `EndPoint`, the previous session will be removed.