### PR TITLE
Performance test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,6 @@ option(EPROSIMA_BUILD_TESTS "Activate the building tests" OFF)
 option(THIRDPARTY "Activate the build of thirdparties" OFF)
 option(VERBOSE "Use verbose output" OFF)
 option(EPROSIMA_INSTALLER "Activate the creation of a build to create Windows installer" OFF)
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    option(PERFORMANCE_TESTS "Performance testing." OFF)
-endif()
 
 if(EPROSIMA_INSTALLER)
     set(THIRDPARTY ON)
@@ -64,10 +61,6 @@ endif()
 if(EPROSIMA_BUILD)
     set(THIRDPARTY ON)
     set(EPROSIMA_BUILD_TESTS ON)
-endif()
-
-if(EPROSIMA_BUILD_TESTS)
-    set(PERFORMANCE_TESTS ON)
 endif()
 
 ###############################################################################
@@ -208,10 +201,9 @@ set_target_properties(MicroXRCEAgent PROPERTIES
 # Definition
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE
-        -DBOOST_ASIO_STANDALONE
-        -DASIO_STANDALONE
-        -D$<$<BOOL:${VERBOSE}>:VERBOSE_OUTPUT>
-        -D$<$<BOOL:${PERFORMANCE_TESTS}>:PERFORMANCE_TESTING>
+        BOOST_ASIO_STANDALONE
+        ASIO_STANDALONE
+        $<$<BOOL:${VERBOSE}>:VERBOSE_OUTPUT>
     )
 
 get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(THIRDPARTY "Activate the build of thirdparties" OFF)
 option(VERBOSE "Use verbose output" OFF)
 option(EPROSIMA_INSTALLER "Activate the creation of a build to create Windows installer" OFF)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    option(PERFORMANCE_TEST "Performance testing." OFF)
+    option(PERFORMANCE_TESTS "Performance testing." OFF)
 endif()
 
 if(EPROSIMA_INSTALLER)
@@ -67,7 +67,7 @@ if(EPROSIMA_BUILD)
 endif()
 
 if(EPROSIMA_BUILD_TESTS)
-    set(PERFORMANCE_TEST ON)
+    set(PERFORMANCE_TESTS ON)
 endif()
 
 ###############################################################################
@@ -211,7 +211,7 @@ target_compile_definitions(${PROJECT_NAME}
         -DBOOST_ASIO_STANDALONE
         -DASIO_STANDALONE
         -D$<$<BOOL:${VERBOSE}>:VERBOSE_OUTPUT>
-        -D$<$<BOOL:${PERFORMANCE_TEST}>:PERFORMANCE_TESTING>
+        -D$<$<BOOL:${PERFORMANCE_TESTS}>:PERFORMANCE_TESTING>
     )
 
 get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ option(EPROSIMA_BUILD_TESTS "Activate the building tests" OFF)
 option(THIRDPARTY "Activate the build of thirdparties" OFF)
 option(VERBOSE "Use verbose output" OFF)
 option(EPROSIMA_INSTALLER "Activate the creation of a build to create Windows installer" OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    option(PERFORMANCE_TEST "Performance testing." OFF)
+endif()
 
 if(EPROSIMA_INSTALLER)
     set(THIRDPARTY ON)
@@ -61,6 +64,10 @@ endif()
 if(EPROSIMA_BUILD)
     set(THIRDPARTY ON)
     set(EPROSIMA_BUILD_TESTS ON)
+endif()
+
+if(EPROSIMA_BUILD_TESTS)
+    set(PERFORMANCE_TEST ON)
 endif()
 
 ###############################################################################
@@ -204,6 +211,7 @@ target_compile_definitions(${PROJECT_NAME}
         -DBOOST_ASIO_STANDALONE
         -DASIO_STANDALONE
         -D$<$<BOOL:${VERBOSE}>:VERBOSE_OUTPUT>
+        -D$<$<BOOL:${PERFORMANCE_TEST}>:PERFORMANCE_TESTING>
     )
 
 get_target_property(TARGET_TYPE ${PROJECT_NAME} TYPE)

--- a/include/uxr/agent/client/session/stream/OutputStream.hpp
+++ b/include/uxr/agent/client/session/stream/OutputStream.hpp
@@ -98,8 +98,7 @@ inline ReliableOutputStream::ReliableOutputStream(ReliableOutputStream&& x)
     : last_sent_(x.last_sent_),
       last_acknown_(x.last_acknown_),
       messages_(std::move(messages_))
-{
-}
+{}
 
 inline ReliableOutputStream& ReliableOutputStream::operator=(ReliableOutputStream&& x)
 {

--- a/include/uxr/agent/message/InputMessage.hpp
+++ b/include/uxr/agent/message/InputMessage.hpp
@@ -52,6 +52,8 @@ public:
     const dds::xrce::MessageHeader& get_header() const { return header_; }
     const dds::xrce::SubmessageHeader& get_subheader() const { return subheader_; }
     template<class T> bool get_payload(T& data);
+    bool get_raw_payload(uint8_t* buf, size_t len);
+    bool jump_payload();
     bool prepare_next_submessage();
 
 private:
@@ -99,6 +101,22 @@ template bool InputMessage::get_payload(dds::xrce::READ_DATA_Payload& data);
 template bool InputMessage::get_payload(dds::xrce::WRITE_DATA_Payload_Data& data);
 template bool InputMessage::get_payload(dds::xrce::HEARTBEAT_Payload& data);
 template bool InputMessage::get_payload(dds::xrce::ACKNACK_Payload& data);
+
+inline bool InputMessage::get_raw_payload(uint8_t* buf, size_t len)
+{
+    bool rv = false;
+    if (subheader_.submessage_length() <= len)
+    {
+        deserializer_.deserializeArray(buf, subheader_.submessage_length(), fastcdr::Cdr::BIG_ENDIANNESS);
+        rv = true;
+    }
+    return rv;
+}
+
+inline bool InputMessage::jump_payload()
+{
+    return deserializer_.jump(size_t(subheader_.submessage_length()));
+}
 
 template<class T> inline bool InputMessage::deserialize(T& data)
 {

--- a/include/uxr/agent/message/InputMessage.hpp
+++ b/include/uxr/agent/message/InputMessage.hpp
@@ -88,7 +88,7 @@ template<class T> inline bool InputMessage::get_payload(T& data)
     }
     catch(eprosima::fastcdr::exception::NotEnoughMemoryException & /*exception*/)
     {
-        std::cout << "deserialize eprosima::fastcdr::exception::NotEnoughMemoryException" << std::endl;
+        std::cerr << "deserialize eprosima::fastcdr::exception::NotEnoughMemoryException" << std::endl;
         rv = false;
     }
     return rv;
@@ -107,8 +107,16 @@ inline bool InputMessage::get_raw_payload(uint8_t* buf, size_t len)
     bool rv = false;
     if (subheader_.submessage_length() <= len)
     {
-        deserializer_.deserializeArray(buf, subheader_.submessage_length(), fastcdr::Cdr::BIG_ENDIANNESS);
         rv = true;
+        try
+        {
+            deserializer_.deserializeArray(buf, subheader_.submessage_length(), fastcdr::Cdr::BIG_ENDIANNESS);
+        }
+        catch(eprosima::fastcdr::exception::NotEnoughMemoryException& /*exception*/)
+        {
+            std::cerr << "deserialize eprosima::fastcdr::exception::NotEnoughMemoryException" << std::endl;
+            rv = false;
+        }
     }
     return rv;
 }
@@ -127,7 +135,7 @@ template<class T> inline bool InputMessage::deserialize(T& data)
     }
     catch(eprosima::fastcdr::exception::NotEnoughMemoryException & /*exception*/)
     {
-        std::cout << "deserialize eprosima::fastcdr::exception::NotEnoughMemoryException" << std::endl;
+        std::cerr << "deserialize eprosima::fastcdr::exception::NotEnoughMemoryException" << std::endl;
         rv = false;
     }
     return rv;

--- a/include/uxr/agent/message/OutputMessage.hpp
+++ b/include/uxr/agent/message/OutputMessage.hpp
@@ -79,7 +79,7 @@ inline bool OutputMessage::append_raw_payload(dds::xrce::SubmessageId submessage
         }
         catch(eprosima::fastcdr::exception::NotEnoughMemoryException & /*exception*/)
         {
-            std::cout << "serialize eprosima::fastcdr::exception::NotEnoughMemoryException" << std::endl;
+            std::cerr << "serialize eprosima::fastcdr::exception::NotEnoughMemoryException" << std::endl;
             rv = false;
         }
     }
@@ -111,7 +111,7 @@ inline bool OutputMessage::serialize(const T& data)
     }
     catch(eprosima::fastcdr::exception::NotEnoughMemoryException & /*exception*/)
     {
-        std::cout << "serialize eprosima::fastcdr::exception::NotEnoughMemoryException" << std::endl;
+        std::cerr << "serialize eprosima::fastcdr::exception::NotEnoughMemoryException" << std::endl;
         rv = false;
     }
     return rv;

--- a/include/uxr/agent/processor/Processor.hpp
+++ b/include/uxr/agent/processor/Processor.hpp
@@ -63,8 +63,7 @@ private:
     bool process_heartbeat_submessage(ProxyClient& client, InputPacket& input_packet);
     bool process_reset_submessage(ProxyClient& client, InputPacket&);
 #ifdef PERFORMANCE_TESTING
-    bool process_echo_submessage(ProxyClient& client, InputPacket& input_packet);
-    bool process_throughput_submessage(ProxyClient& client, InputPacket& input_packet);
+    bool process_performance_submessage(ProxyClient& client, InputPacket& input_packet);
 #endif
 
     void read_data_callback(const ReadCallbackArgs& cb_args, const std::vector<uint8_t>& buffer);

--- a/include/uxr/agent/processor/Processor.hpp
+++ b/include/uxr/agent/processor/Processor.hpp
@@ -62,6 +62,10 @@ private:
     bool process_acknack_submessage(ProxyClient& client, InputPacket& input_packet);
     bool process_heartbeat_submessage(ProxyClient& client, InputPacket& input_packet);
     bool process_reset_submessage(ProxyClient& client, InputPacket&);
+#ifdef PERFORMANCE_TESTING
+    bool process_echo_submessage(ProxyClient& client, InputPacket& input_packet);
+    bool process_throughput_submessage(ProxyClient& client, InputPacket& input_packet);
+#endif
 
     void read_data_callback(const ReadCallbackArgs& cb_args, const std::vector<uint8_t>& buffer);
 

--- a/include/uxr/agent/processor/Processor.hpp
+++ b/include/uxr/agent/processor/Processor.hpp
@@ -62,9 +62,7 @@ private:
     bool process_acknack_submessage(ProxyClient& client, InputPacket& input_packet);
     bool process_heartbeat_submessage(ProxyClient& client, InputPacket& input_packet);
     bool process_reset_submessage(ProxyClient& client, InputPacket&);
-#ifdef PERFORMANCE_TESTING
     bool process_performance_submessage(ProxyClient& client, InputPacket& input_packet);
-#endif
 
     void read_data_callback(const ReadCallbackArgs& cb_args, const std::vector<uint8_t>& buffer);
 

--- a/include/uxr/agent/types/SubMessageHeader.hpp
+++ b/include/uxr/agent/types/SubMessageHeader.hpp
@@ -39,6 +39,7 @@ enum SubmessageHeaderFlags : uint8_t
     FLAG_REUSE = 0x01 << 1,
     FLAG_REPLACE = 0x01 << 2,
     FLAG_LAST_FRAGMENT = 0x01 << 1,
+    FLAG_ECHO = 0x01 << 7,
     FORMAT_DATA_FLAG = 0x00,
     FORMAT_SAMPLE_FLAG = 0x02,
     FORMAT_DATA_SEQ_FLAG = 0x08,

--- a/include/uxr/agent/types/XRCETypes.hpp
+++ b/include/uxr/agent/types/XRCETypes.hpp
@@ -10394,11 +10394,8 @@ enum SubmessageId : uint8_t
     ACKNACK         = 10,
     HEARTBEAT       = 11,
     RESET           = 12,
-    FRAGMENT        = 13
-#ifdef PERFORMANCE_TESTING
-    ,
+    FRAGMENT        = 13,
     PERFORMANCE     = 14
-#endif
 };
 
 } } // namespace 

--- a/include/uxr/agent/types/XRCETypes.hpp
+++ b/include/uxr/agent/types/XRCETypes.hpp
@@ -10374,6 +10374,72 @@ private:
     uint16_t m_last_unacked_seq_nr;
     uint8_t m_stream_id;
 };
+
+#ifdef PERFORMANCE_TESTING
+/*!
+ * @brief This class represents the structure ECHO_Payload.
+ * @ingroup TYPESMOD
+ */
+class ECHO_Payload : public BaseObjectRequest
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    ECHO_Payload() = default;
+
+    /*!
+     * @brief Default destructor.
+     */
+    ~ECHO_Payload() = default;
+
+    /*!
+     * @brief This function returns the maximum serialized size of an object
+     * depending on the buffer alignment.
+     * @param current_alignment Buffer alignment.
+     * @return Maximum serialized size.
+     */
+    static size_t getMaxCdrSerializedSize(size_t current_alignment = 0)
+    {
+        size_t initial_aligment = current_alignment;
+        current_alignment += dds::xrce::BaseObjectRequest::getMaxCdrSerializedSize(current_alignment);
+        return current_alignment - initial_aligment;
+    }
+
+    /*!
+     * @brief This function returns the serialized size of a data depending on the buffer alignment.
+     * @param data Data which is calculated its serialized size.
+     * @param current_alignment Buffer alignment.
+     * @return Serialized size.
+     */
+    virtual size_t getCdrSerializedSize(size_t current_aligment = 0) const
+    {
+        size_t initial_aligment = current_aligment;
+        current_aligment += dds::xrce::BaseObjectRequest::getCdrSerializedSize(current_aligment);
+        return current_aligment - initial_aligment;
+    }
+
+    /*!
+     * @brief This function serializes an object using CDR serialization.
+     * @param cdr CDR serialization object.
+     */
+    virtual void serialize(eprosima::fastcdr::Cdr &scdr) const
+    {
+        BaseObjectRequest::serialize(scdr);
+    }
+
+    /*!
+     * @brief This function deserializes an object using CDR serialization.
+     * @param cdr CDR serialization object.
+     */
+    virtual void deserialize(eprosima::fastcdr::Cdr &dcdr)
+    {
+        BaseObjectRequest::serialize(dcdr);
+    }
+};
+#endif
+
 /*!
  * @brief This class represents the enumeration SubmessageId defined by the user in the IDL file.
  * @ingroup TYPESMOD
@@ -10394,6 +10460,11 @@ enum SubmessageId : uint8_t
     HEARTBEAT       = 11,
     RESET           = 12,
     FRAGMENT        = 13
+#ifdef PERFORMANCE_TESTING
+    ,
+    ECHO            = 14,
+    THROUGHPUT      = 15
+#endif
 };
 
 } } // namespace 

--- a/include/uxr/agent/types/XRCETypes.hpp
+++ b/include/uxr/agent/types/XRCETypes.hpp
@@ -10435,7 +10435,7 @@ public:
      */
     virtual void deserialize(eprosima::fastcdr::Cdr &dcdr)
     {
-        BaseObjectRequest::serialize(dcdr);
+        BaseObjectRequest::deserialize(dcdr);
     }
 };
 #endif

--- a/include/uxr/agent/types/XRCETypes.hpp
+++ b/include/uxr/agent/types/XRCETypes.hpp
@@ -10375,71 +10375,6 @@ private:
     uint8_t m_stream_id;
 };
 
-#ifdef PERFORMANCE_TESTING
-/*!
- * @brief This class represents the structure ECHO_Payload.
- * @ingroup TYPESMOD
- */
-class ECHO_Payload : public BaseObjectRequest
-{
-public:
-
-    /*!
-     * @brief Default constructor.
-     */
-    ECHO_Payload() = default;
-
-    /*!
-     * @brief Default destructor.
-     */
-    ~ECHO_Payload() = default;
-
-    /*!
-     * @brief This function returns the maximum serialized size of an object
-     * depending on the buffer alignment.
-     * @param current_alignment Buffer alignment.
-     * @return Maximum serialized size.
-     */
-    static size_t getMaxCdrSerializedSize(size_t current_alignment = 0)
-    {
-        size_t initial_aligment = current_alignment;
-        current_alignment += dds::xrce::BaseObjectRequest::getMaxCdrSerializedSize(current_alignment);
-        return current_alignment - initial_aligment;
-    }
-
-    /*!
-     * @brief This function returns the serialized size of a data depending on the buffer alignment.
-     * @param data Data which is calculated its serialized size.
-     * @param current_alignment Buffer alignment.
-     * @return Serialized size.
-     */
-    virtual size_t getCdrSerializedSize(size_t current_aligment = 0) const
-    {
-        size_t initial_aligment = current_aligment;
-        current_aligment += dds::xrce::BaseObjectRequest::getCdrSerializedSize(current_aligment);
-        return current_aligment - initial_aligment;
-    }
-
-    /*!
-     * @brief This function serializes an object using CDR serialization.
-     * @param cdr CDR serialization object.
-     */
-    virtual void serialize(eprosima::fastcdr::Cdr &scdr) const
-    {
-        BaseObjectRequest::serialize(scdr);
-    }
-
-    /*!
-     * @brief This function deserializes an object using CDR serialization.
-     * @param cdr CDR serialization object.
-     */
-    virtual void deserialize(eprosima::fastcdr::Cdr &dcdr)
-    {
-        BaseObjectRequest::deserialize(dcdr);
-    }
-};
-#endif
-
 /*!
  * @brief This class represents the enumeration SubmessageId defined by the user in the IDL file.
  * @ingroup TYPESMOD
@@ -10462,8 +10397,7 @@ enum SubmessageId : uint8_t
     FRAGMENT        = 13
 #ifdef PERFORMANCE_TESTING
     ,
-    ECHO            = 14,
-    THROUGHPUT      = 15
+    PERFORMANCE     = 14
 #endif
 };
 

--- a/microxrce_agent.cpp
+++ b/microxrce_agent.cpp
@@ -194,6 +194,8 @@ int main(int argc, char** argv)
                 tcgetattr(fd, &attr);
                 cfmakeraw(&attr);
                 tcflush(fd, TCIOFLUSH);
+                cfsetispeed(&attr, B115200);
+                cfsetospeed(&attr, B115200);
                 tcsetattr(fd, TCSANOW, &attr);
                 std::cout << "Device: " << dev << std::endl;
             }

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -150,11 +150,9 @@ bool Processor::process_submessage(ProxyClient& client, InputPacket& input_packe
             // TODO (julian): implement fragment functionality.
             rv = false;
             break;
-#ifdef PERFORMANCE_TESTING
         case dds::xrce::PERFORMANCE:
             rv = process_performance_submessage(client, input_packet);
             break;
-#endif
         default:
             rv = false;
             break;
@@ -305,7 +303,6 @@ bool Processor::process_delete_submessage(ProxyClient& client, InputPacket& inpu
             {
                 server_->on_delete_client(input_packet.source.get());
             }
-            output_packet.message = OutputMessagePtr(new OutputMessage(status_header));
         }
         else
         {
@@ -317,10 +314,8 @@ bool Processor::process_delete_submessage(ProxyClient& client, InputPacket& inpu
 
             /* Set result status. */
             status_payload.result(client.delete_object(delete_payload.object_id()));
-
-            /* Store message. */
-            output_packet.message = OutputMessagePtr(new OutputMessage(status_header));
         }
+        output_packet.message = OutputMessagePtr(new OutputMessage(status_header));
         output_packet.message->append_submessage(dds::xrce::STATUS, status_payload, 0);
 
         /* Store message. */
@@ -527,7 +522,6 @@ bool Processor::process_reset_submessage(ProxyClient& client, InputPacket& /*inp
     return true;
 }
 
-#ifdef PERFORMANCE_TESTING
 bool Processor::process_performance_submessage(ProxyClient& client, InputPacket& input_packet)
 {
     /* Set output packet. */
@@ -535,7 +529,7 @@ bool Processor::process_performance_submessage(ProxyClient& client, InputPacket&
     output_packet.destination = input_packet.source;
 
     /* Get epoch time and array. */
-    uint8_t buf[65536];
+    uint8_t buf[UINT16_MAX];
     uint16_t submessage_len = input_packet.message->get_subheader().submessage_length();
     input_packet.message->get_raw_payload(buf, size_t(submessage_len));
 
@@ -560,7 +554,6 @@ bool Processor::process_performance_submessage(ProxyClient& client, InputPacket&
     }
     return true;
 }
-#endif
 
 void Processor::read_data_callback(const ReadCallbackArgs& cb_args, const std::vector<uint8_t>& buffer)
 {

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -341,10 +341,9 @@ bool Processor::process_write_data_submessage(ProxyClient& client, InputPacket& 
     bool rv = true;
     bool deserialized = false, written = false;
     uint8_t flags = input_packet.message->get_subheader().flags() & 0x0E;
-    dds::xrce::DataRepresentation data;
     switch (flags)
     {
-        case dds::xrce::FORMAT_DATA_FLAG: ;
+        case dds::xrce::FORMAT_DATA_FLAG:
         {
             dds::xrce::WRITE_DATA_Payload_Data data_payload;
             if (input_packet.message->get_payload(data_payload))
@@ -544,8 +543,7 @@ bool Processor::process_echo_submessage(ProxyClient& client, InputPacket& input_
 bool Processor::process_throughput_submessage(ProxyClient& client, InputPacket& input_packet)
 {
     (void) client;
-    (void) input_packet;
-    return true;
+    return input_packet.message->jump_payload();
 }
 #endif
 

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -150,6 +150,14 @@ bool Processor::process_submessage(ProxyClient& client, InputPacket& input_packe
             // TODO (julian): implement fragment functionality.
             rv = false;
             break;
+#ifdef PERFORMANCE_TESTING
+        case dds::xrce::ECHO:
+            rv = process_echo_submessage(client, input_packet);
+            break;
+        case dds::xrce::THROUGHPUT:
+            rv = process_throughput_submessage(client, input_packet);
+            break;
+#endif
         default:
             rv = false;
             break;
@@ -516,6 +524,30 @@ bool Processor::process_reset_submessage(ProxyClient& client, InputPacket& /*inp
     client.session().reset();
     return true;
 }
+
+#ifdef PERFORMANCE_TESTING
+bool Processor::process_echo_submessage(ProxyClient& client, InputPacket& input_packet)
+{
+    /* Set output packet. */
+    OutputPacket output_packet;
+    output_packet.destination = input_packet.source;
+    dds::xrce::ECHO_Payload echo_payload;
+    input_packet.message->get_payload(echo_payload);
+    output_packet.message = OutputMessagePtr(new OutputMessage(input_packet.message->get_header()));
+    output_packet.message->append_submessage(dds::xrce::ECHO, echo_payload);
+    client.session().push_output_message(input_packet.message->get_header().stream_id(),
+                                         output_packet.message);
+    server_->push_output_packet(output_packet);
+    return true;
+}
+
+bool Processor::process_throughput_submessage(ProxyClient& client, InputPacket& input_packet)
+{
+    (void) client;
+    (void) input_packet;
+    return true;
+}
+#endif
 
 void Processor::read_data_callback(const ReadCallbackArgs& cb_args, const std::vector<uint8_t>& buffer)
 {

--- a/src/cpp/transport/Server.cpp
+++ b/src/cpp/transport/Server.cpp
@@ -17,7 +17,7 @@
 #include <uxr/agent/processor/Processor.hpp>
 #include <functional>
 
-#define RECEIVE_TIMEOUT 100
+#define RECEIVE_TIMEOUT 1
 
 namespace eprosima {
 namespace uxr {

--- a/src/cpp/transport/serial/serial_protocol.c
+++ b/src/cpp/transport/serial/serial_protocol.c
@@ -255,7 +255,7 @@ size_t uxr_read_serial_msg(uxrSerialIO* serial_io,
         }
     }
 
-    if (0 < (bytes_read[0] + bytes_read[1]))
+    if (0 < (bytes_read[0] + bytes_read[1]) || (serial_io->rb_tail != serial_io->rb_head))
     {
         /* State Machine. */
         bool exit_cond = false;

--- a/src/cpp/transport/tcp/TCPServerLinux.cpp
+++ b/src/cpp/transport/tcp/TCPServerLinux.cpp
@@ -207,7 +207,7 @@ bool TCPServer::send_message(OutputPacket output_packet)
             while (!payload_sent && n_attemps < max_attemps);
         }
 
-        if (size_sent && payload_sent)
+        if (payload_sent)
         {
             rv = true;
         }

--- a/src/cpp/transport/tcp/TCPServerLinux.cpp
+++ b/src/cpp/transport/tcp/TCPServerLinux.cpp
@@ -181,6 +181,7 @@ bool TCPServer::send_message(OutputPacket output_packet)
         bool payload_sent = false;
         if (size_sent)
         {
+            n_attemps = 0;
             bytes_sent = 0;
             do
             {
@@ -201,6 +202,7 @@ bool TCPServer::send_message(OutputPacket output_packet)
                         break;
                     }
                 }
+                ++n_attemps;
             }
             while (!payload_sent && n_attemps < max_attemps);
         }

--- a/src/cpp/transport/tcp/TCPServerWindows.cpp
+++ b/src/cpp/transport/tcp/TCPServerWindows.cpp
@@ -18,6 +18,8 @@
 namespace eprosima {
 namespace uxr {
 
+const uint8_t max_attemps = 16;
+
 TCPServer::TCPServer(uint16_t port)
     : TCPServerBase(port),
       connections_{},
@@ -123,9 +125,7 @@ bool TCPServer::recv_message(InputPacket& input_packet, int timeout)
 
 bool TCPServer::send_message(OutputPacket output_packet)
 {
-    bool rv = true;
-    uint16_t bytes_sent = 0;
-    size_t send_rv = 0;
+    bool rv = false;
     uint8_t msg_size_buf[2];
     const TCPEndPoint* destination = static_cast<const TCPEndPoint*>(output_packet.destination.get());
     uint64_t source_id = (uint64_t(destination->get_addr()) << 16) | destination->get_port();
@@ -137,53 +137,68 @@ bool TCPServer::send_message(OutputPacket output_packet)
         TCPConnection& connection = connections_.at(it->second);
         lock.unlock();
 
-        /* Send message size. */
         msg_size_buf[0] = uint8_t(0x00FF & output_packet.message->get_len());
         msg_size_buf[1] = uint8_t((0xFF00 & output_packet.message->get_len()) >> 8);
+        uint8_t n_attemps = 0;
+        uint16_t bytes_sent = 0;
+
+        /* Send message size. */
+        bool size_sent = false;
         do
         {
             uint8_t errcode;
-            send_rv = send_locking(connection, msg_size_buf, size_t(2), errcode);
+            size_t send_rv = send_locking(connection, msg_size_buf, size_t(2), errcode);
             if (0 < send_rv)
             {
                 bytes_sent += uint16_t(send_rv);
+                size_sent = (bytes_sent == 2);
             }
             else
             {
                 if (0 < errcode)
                 {
-                    close_connection(connection);
-                    rv = false;
+                    break;
                 }
             }
+            ++n_attemps;
         }
-        while (rv && bytes_sent != 2);
+        while (!size_sent && n_attemps < max_attemps);
 
         /* Send message payload. */
-        if (rv)
+        bool payload_sent = false;
+        if (size_sent)
         {
             bytes_sent = 0;
             do
             {
                 uint8_t errcode;
-                send_rv = send_locking(connection,
-                                       (output_packet.message->get_buf() + bytes_sent),
-                                       size_t(output_packet.message->get_len() - bytes_sent),
-                                       errcode);
+                size_t send_rv = send_locking(connection,
+                                              (output_packet.message->get_buf() + bytes_sent),
+                                              size_t(output_packet.message->get_len() - bytes_sent),
+                                              errcode);
                 if (0 < send_rv)
                 {
                     bytes_sent += uint16_t(send_rv);
+                    payload_sent = (bytes_sent == uint16_t(output_packet.message->get_len()));
                 }
                 else
                 {
                     if (0 < errcode)
                     {
-                        close_connection(connection);
-                        rv = false;
+                        break;
                     }
                 }
             }
-            while (rv && bytes_sent != uint16_t(output_packet.message->get_len()));
+            while (!payload_sent && n_attemps < max_attemps);
+        }
+
+        if (size_sent && payload_sent)
+        {
+            rv = true;
+        }
+        else
+        {
+            close_connection(connection);
         }
     }
 
@@ -207,6 +222,7 @@ bool TCPServer::open_connection(SOCKET fd, struct sockaddr_in* sockaddr)
         connection.addr = sockaddr->sin_addr.s_addr;
         connection.port = sockaddr->sin_port;
         connection.active = true;
+        init_input_buffer(connection.input_buffer);
 
         uint64_t source_id = (uint64_t(connection.addr) << 16) | connection.port;
         source_to_connection_map_[source_id] = connection.id;

--- a/src/cpp/transport/tcp/TCPServerWindows.cpp
+++ b/src/cpp/transport/tcp/TCPServerWindows.cpp
@@ -168,6 +168,7 @@ bool TCPServer::send_message(OutputPacket output_packet)
         bool payload_sent = false;
         if (size_sent)
         {
+            n_attemps = 0;
             bytes_sent = 0;
             do
             {
@@ -188,6 +189,7 @@ bool TCPServer::send_message(OutputPacket output_packet)
                         break;
                     }
                 }
+                ++n_attemps;
             }
             while (!payload_sent && n_attemps < max_attemps);
         }

--- a/src/cpp/transport/tcp/TCPServerWindows.cpp
+++ b/src/cpp/transport/tcp/TCPServerWindows.cpp
@@ -194,7 +194,7 @@ bool TCPServer::send_message(OutputPacket output_packet)
             while (!payload_sent && n_attemps < max_attemps);
         }
 
-        if (size_sent && payload_sent)
+        if (payload_sent)
         {
             rv = true;
         }


### PR DESCRIPTION
This pull request adds support for the performance test. It has the following changes:
* The CMakeLists.txt has been modified with a new flag for activating the performance test.
* A new submessage (PERFORMANCE) has been introduced.
The payload of this new submessage is composed by the epoch_time (64 bit), following by an array of octets with variable length. This submessage has two main purposes: 1) receive raw data from the Client in order to test the throughput, and 2) send echoes message for measuring the latency between the Agent and the Client.
