### PR TITLE
Input fragmentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ option(EPROSIMA_BUILD_TESTS "Activate the building tests" OFF)
 option(THIRDPARTY "Activate the build of thirdparties" OFF)
 option(VERBOSE "Use verbose output" OFF)
 option(EPROSIMA_INSTALLER "Activate the creation of a build to create Windows installer" OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    option(PERFORMANCE_TEST "Performance testing." OFF)
+endif()
 
 if(EPROSIMA_INSTALLER)
     set(THIRDPARTY ON)
@@ -61,6 +64,10 @@ endif()
 if(EPROSIMA_BUILD)
     set(THIRDPARTY ON)
     set(EPROSIMA_BUILD_TESTS ON)
+endif()
+
+if(EPROSIMA_BUILD_TESTS)
+    set(PERFORMANCE_TEST ON)
 endif()
 
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(THIRDPARTY "Activate the build of thirdparties" OFF)
 option(VERBOSE "Use verbose output" OFF)
 option(EPROSIMA_INSTALLER "Activate the creation of a build to create Windows installer" OFF)
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    option(PERFORMANCE_TEST "Performance testing." OFF)
+    option(PERFORMANCE_TESTS "Performance testing." OFF)
 endif()
 
 if(EPROSIMA_INSTALLER)
@@ -67,7 +67,7 @@ if(EPROSIMA_BUILD)
 endif()
 
 if(EPROSIMA_BUILD_TESTS)
-    set(PERFORMANCE_TEST ON)
+    set(PERFORMANCE_TESTS ON)
 endif()
 
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,6 @@ option(EPROSIMA_BUILD_TESTS "Activate the building tests" OFF)
 option(THIRDPARTY "Activate the build of thirdparties" OFF)
 option(VERBOSE "Use verbose output" OFF)
 option(EPROSIMA_INSTALLER "Activate the creation of a build to create Windows installer" OFF)
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    option(PERFORMANCE_TESTS "Performance testing." OFF)
-endif()
 
 if(EPROSIMA_INSTALLER)
     set(THIRDPARTY ON)
@@ -64,10 +61,6 @@ endif()
 if(EPROSIMA_BUILD)
     set(THIRDPARTY ON)
     set(EPROSIMA_BUILD_TESTS ON)
-endif()
-
-if(EPROSIMA_BUILD_TESTS)
-    set(PERFORMANCE_TESTS ON)
 endif()
 
 ###############################################################################

--- a/include/uxr/agent/client/session/Session.hpp
+++ b/include/uxr/agent/client/session/Session.hpp
@@ -43,6 +43,8 @@ public:
     void update_from_heartbeat(dds::xrce::StreamId stream_id, SeqNum first_unacked, SeqNum last_unacked);
     SeqNum get_first_unacked_seq_num(dds::xrce::StreamId stream_id);
     std::array<uint8_t, 2> get_nack_bitmap(dds::xrce::StreamId stream_id);
+    void push_input_fragment(dds::xrce::StreamId stream_id, InputMessagePtr& message);
+    bool pop_input_fragment_message(dds::xrce::StreamId stream_id, InputMessagePtr& message);
 
     /* Output streams functions. */
     bool push_output_message(dds::xrce::StreamId stream_id, OutputMessagePtr& output_message);
@@ -161,6 +163,19 @@ inline std::array<uint8_t, 2> Session::get_nack_bitmap(const dds::xrce::StreamId
         bitmap = relible_istreams_[stream_id].get_nack_bitmap();
     }
     return bitmap;
+}
+
+inline void Session::push_input_fragment(dds::xrce::StreamId stream_id, InputMessagePtr& message)
+{
+    if (127 < stream_id)
+    {
+        relible_istreams_[stream_id].push_fragment(message);
+    }
+}
+
+inline bool Session::pop_input_fragment_message(dds::xrce::StreamId stream_id, InputMessagePtr& message)
+{
+    return relible_istreams_[stream_id].pop_fragment_message(message);
 }
 
 /**************************************************************************************************

--- a/include/uxr/agent/client/session/stream/InputStream.hpp
+++ b/include/uxr/agent/client/session/stream/InputStream.hpp
@@ -208,7 +208,7 @@ inline void ReliableInputStream::push_fragment(InputMessagePtr& message)
     message->get_raw_payload(fragment_msg_.data() + position, fragment_size);
 
     /* Check if last message. */
-    fragment_message_available_ = (0 < (dds::xrce::FLAG_LAST_FRAGMENT & message->get_subheader().flags()));
+    fragment_message_available_ = (0 != (dds::xrce::FLAG_LAST_FRAGMENT & message->get_subheader().flags()));
 }
 
 inline bool ReliableInputStream::pop_fragment_message(InputMessagePtr& message)

--- a/include/uxr/agent/client/session/stream/InputStream.hpp
+++ b/include/uxr/agent/client/session/stream/InputStream.hpp
@@ -75,11 +75,6 @@ public:
     void push_fragment(InputMessagePtr& message);
     bool pop_fragment_message(InputMessagePtr& message);
 
-
-    bool fragment_init() { return !fragment_msg_.empty(); }
-    uint8_t* prepare_to_append_fragment(size_t len);
-    void get_fragment_msg(InputMessagePtr& message);
-
 private:
     SeqNum last_handled_;
     SeqNum last_announced_;
@@ -227,19 +222,6 @@ inline bool ReliableInputStream::pop_fragment_message(InputMessagePtr& message)
         return true;
     }
     return rv;
-}
-
-inline uint8_t* ReliableInputStream::prepare_to_append_fragment(size_t len)
-{
-    size_t position = fragment_msg_.size();
-    fragment_msg_.resize(position + len, 0);
-    return fragment_msg_.data() + position;
-}
-
-inline void ReliableInputStream::get_fragment_msg(InputMessagePtr& message)
-{
-    // TODO
-    (void)message;
 }
 
 } // namespace uxr

--- a/include/uxr/agent/client/session/stream/InputStream.hpp
+++ b/include/uxr/agent/client/session/stream/InputStream.hpp
@@ -203,14 +203,14 @@ inline void ReliableInputStream::push_fragment(InputMessagePtr& message)
     {
         std::array<uint8_t, 8> raw_header;
         uint8_t header_size = message->get_raw_header(raw_header);
-        fragment_msg_.insert(fragment_msg_.begin(), raw_header.at(0), raw_header.at(header_size - 1));
+        fragment_msg_.insert(fragment_msg_.begin(), std::begin(raw_header), std::begin(raw_header) + header_size);
     }
 
     /* Append fragment. */
     size_t position = fragment_msg_.size();
     size_t fragment_size = message->get_subheader().submessage_length();
     fragment_msg_.resize(position + fragment_size);
-    message->get_raw_payload(fragment_msg_.data() + fragment_size, fragment_size);
+    message->get_raw_payload(fragment_msg_.data() + position, fragment_size);
 
     /* Check if last message. */
     fragment_message_available_ = (0 < (dds::xrce::FLAG_LAST_FRAGMENT & message->get_subheader().flags()));
@@ -224,6 +224,7 @@ inline bool ReliableInputStream::pop_fragment_message(InputMessagePtr& message)
         message.reset(new InputMessage(fragment_msg_.data(), fragment_msg_.size()));
         fragment_msg_.clear();
         fragment_message_available_ = false;
+        return true;
     }
     return rv;
 }

--- a/include/uxr/agent/client/session/stream/InputStream.hpp
+++ b/include/uxr/agent/client/session/stream/InputStream.hpp
@@ -54,7 +54,12 @@ inline bool BestEffortInputStream::next_message(SeqNum seq_num)
 class ReliableInputStream
 {
 public:
-    ReliableInputStream() : last_handled_(~0), last_announced_(~0) {}
+    ReliableInputStream()
+        : last_handled_(~0),
+          last_announced_(~0),
+          fragment_msg_{},
+          fragment_message_available_(false)
+    {}
 
     ReliableInputStream(const ReliableInputStream&) = delete;
     ReliableInputStream& operator=(const ReliableInputStream) = delete;
@@ -67,11 +72,20 @@ public:
     SeqNum get_first_unacked() const;
     std::array<uint8_t, 2> get_nack_bitmap();
     void reset();
+    void push_fragment(InputMessagePtr& message);
+    bool pop_fragment_message(InputMessagePtr& message);
+
+
+    bool fragment_init() { return !fragment_msg_.empty(); }
+    uint8_t* prepare_to_append_fragment(size_t len);
+    void get_fragment_msg(InputMessagePtr& message);
 
 private:
     SeqNum last_handled_;
     SeqNum last_announced_;
     std::map<uint16_t, InputMessagePtr> messages_;
+    std::vector<uint8_t> fragment_msg_;
+    bool fragment_message_available_;
 };
 
 inline ReliableInputStream::ReliableInputStream(ReliableInputStream&& x)
@@ -112,7 +126,6 @@ inline bool ReliableInputStream::next_message(SeqNum seq_num, InputMessagePtr& m
                 if (it == messages_.end())
                 {
                     messages_.insert(std::make_pair(seq_num, std::move(message)));
-
                 }
             }
         }
@@ -181,6 +194,51 @@ inline void ReliableInputStream::reset()
     last_handled_ = ~0;
     last_announced_ = ~0;
     messages_.clear();
+}
+
+inline void ReliableInputStream::push_fragment(InputMessagePtr& message)
+{
+    /* Add header in case. */
+    if (fragment_msg_.empty())
+    {
+        std::array<uint8_t, 8> raw_header;
+        uint8_t header_size = message->get_raw_header(raw_header);
+        fragment_msg_.insert(fragment_msg_.begin(), raw_header.at(0), raw_header.at(header_size - 1));
+    }
+
+    /* Append fragment. */
+    size_t position = fragment_msg_.size();
+    size_t fragment_size = message->get_subheader().submessage_length();
+    fragment_msg_.resize(position + fragment_size);
+    message->get_raw_payload(fragment_msg_.data() + fragment_size, fragment_size);
+
+    /* Check if last message. */
+    fragment_message_available_ = (0 < (dds::xrce::FLAG_LAST_FRAGMENT & message->get_subheader().flags()));
+}
+
+inline bool ReliableInputStream::pop_fragment_message(InputMessagePtr& message)
+{
+    bool rv = false;
+    if (fragment_message_available_)
+    {
+        message.reset(new InputMessage(fragment_msg_.data(), fragment_msg_.size()));
+        fragment_msg_.clear();
+        fragment_message_available_ = false;
+    }
+    return rv;
+}
+
+inline uint8_t* ReliableInputStream::prepare_to_append_fragment(size_t len)
+{
+    size_t position = fragment_msg_.size();
+    fragment_msg_.resize(position + len, 0);
+    return fragment_msg_.data() + position;
+}
+
+inline void ReliableInputStream::get_fragment_msg(InputMessagePtr& message)
+{
+    // TODO
+    (void)message;
 }
 
 } // namespace uxr

--- a/include/uxr/agent/message/InputMessage.hpp
+++ b/include/uxr/agent/message/InputMessage.hpp
@@ -52,6 +52,7 @@ public:
     const dds::xrce::MessageHeader& get_header() const { return header_; }
     const dds::xrce::SubmessageHeader& get_subheader() const { return subheader_; }
     template<class T> bool get_payload(T& data);
+    uint8_t get_raw_header(std::array<uint8_t, 8>& buf);
     bool get_raw_payload(uint8_t* buf, size_t len);
     bool jump_payload();
     bool prepare_next_submessage();
@@ -101,6 +102,22 @@ template bool InputMessage::get_payload(dds::xrce::READ_DATA_Payload& data);
 template bool InputMessage::get_payload(dds::xrce::WRITE_DATA_Payload_Data& data);
 template bool InputMessage::get_payload(dds::xrce::HEARTBEAT_Payload& data);
 template bool InputMessage::get_payload(dds::xrce::ACKNACK_Payload& data);
+
+inline uint8_t InputMessage::get_raw_header(std::array<uint8_t, 8>& buf)
+{
+    uint8_t rv;
+    if (128 > header_.session_id())
+    {
+        memcpy(buf.data(), buf_, 4);
+        rv = 4;
+    }
+    else
+    {
+        memcpy(buf.data(), buf_, 8);
+        rv = 8;
+    }
+    return rv;
+}
 
 inline bool InputMessage::get_raw_payload(uint8_t* buf, size_t len)
 {

--- a/include/uxr/agent/message/InputMessage.hpp
+++ b/include/uxr/agent/message/InputMessage.hpp
@@ -108,13 +108,13 @@ inline uint8_t InputMessage::get_raw_header(std::array<uint8_t, 8>& buf)
     uint8_t rv;
     if (128 > header_.session_id())
     {
-        memcpy(buf.data(), buf_, 4);
-        rv = 4;
+        memcpy(buf.data(), buf_, 8);
+        rv = 8;
     }
     else
     {
-        memcpy(buf.data(), buf_, 8);
-        rv = 8;
+        memcpy(buf.data(), buf_, 4);
+        rv = 4;
     }
     return rv;
 }

--- a/include/uxr/agent/processor/Processor.hpp
+++ b/include/uxr/agent/processor/Processor.hpp
@@ -70,7 +70,7 @@ private:
 private:
     Server* server_;
     Root* root_;
-    std::mutex mtx_;
+    std::recursive_mutex mtx_;
 };
 
 } // namespace uxr

--- a/include/uxr/agent/processor/Processor.hpp
+++ b/include/uxr/agent/processor/Processor.hpp
@@ -62,6 +62,7 @@ private:
     bool process_acknack_submessage(ProxyClient& client, InputPacket& input_packet);
     bool process_heartbeat_submessage(ProxyClient& client, InputPacket& input_packet);
     bool process_reset_submessage(ProxyClient& client, InputPacket&);
+    bool process_fragment_submessage(ProxyClient& client, InputPacket& input_packet);
     bool process_performance_submessage(ProxyClient& client, InputPacket& input_packet);
 
     void read_data_callback(const ReadCallbackArgs& cb_args, const std::vector<uint8_t>& buffer);


### PR DESCRIPTION
This pull request implements fragmentation for input messages received from the Clients.
It has involved the following changes:

- `push_fragment` and `pop_fragment_message` function have been added to `ReliableInputStream`.
- `get_raw_header` has been added to `InputMessage`.
- `process_fragment_submessage` has been implemented in `Processor`.



Before approve this pull request:

- [x] Approve #33 pull request.