### PR TITLE
Output fragmentation

### DIFF
--- a/cmake/common/eprosima_libraries.cmake
+++ b/cmake/common/eprosima_libraries.cmake
@@ -57,7 +57,7 @@ macro(eprosima_find_package package)
                 endforeach()
                 # Keep temp value in order to avoid call packages' installer.
                 set(EPROSIMA_INSTALLER_TEMP ${EPROSIMA_INSTALLER})
-                set(EPROSIMA_INSTALLER OFF)
+                unset(EPROSIMA_INSTALLER CACHE)
                 add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/${package})
                 set(EPROSIMA_INSTALLER ${EPROSIMA_INSTALLER_TEMP})
                 set(${package}_FOUND TRUE)

--- a/include/uxr/agent/client/session/Session.hpp
+++ b/include/uxr/agent/client/session/Session.hpp
@@ -53,7 +53,7 @@ public:
                                             std::forward_as_tuple(session_id, stream_id, client_key, mtu));
         }
 
-        /* Create Relaible output streams. */
+        /* Create Reliable output streams. */
         for (int i = 128; i <= 255; ++i)
         {
             dds::xrce::StreamId stream_id = dds::xrce::StreamId(i);

--- a/include/uxr/agent/client/session/Session.hpp
+++ b/include/uxr/agent/client/session/Session.hpp
@@ -82,11 +82,11 @@ public:
     bool pop_input_fragment_message(dds::xrce::StreamId stream_id, InputMessagePtr& message);
 
     /* Output streams functions. */
-//    bool push_output_message(dds::xrce::StreamId stream_id, OutputMessagePtr& output_message);
+    bool push_output_message(dds::xrce::StreamId stream_id, OutputMessagePtr& output_message);
     SeqNum get_first_unacked_seq_nr(dds::xrce::StreamId stream_id);
     SeqNum get_last_unacked_seq_nr(dds::xrce::StreamId stream_id);
     void update_from_acknack(dds::xrce::StreamId stream_id, SeqNum first_unacked);
-//    SeqNum next_output_message(dds::xrce::StreamId stream_id);
+    SeqNum next_output_message(dds::xrce::StreamId stream_id);
     std::vector<uint8_t> get_output_streams();
     bool message_pending(dds::xrce::StreamId stream_id);
 
@@ -203,22 +203,20 @@ inline bool Session::pop_input_fragment_message(dds::xrce::StreamId stream_id, I
 /**************************************************************************************************
  * Output Stream Methods.
  **************************************************************************************************/
-//inline bool Session::push_output_message(dds::xrce::StreamId stream_id, OutputMessagePtr& output_message)
-//{
-//    bool rv = false;
-//    if (128 > stream_id)
-//    {
-//        std::lock_guard<std::mutex> bo_lock(bo_mtx_);
-//        besteffort_out_streams_.at(stream_id).promote_stream();
-//        rv = true;
-//    }
-//    else
-//    {
-//        std::lock_guard<std::mutex> ro_lock(ro_mtx_);
-//        rv = reliable_out_streams_.at(stream_id).push_message(output_message);
-//    }
-//    return rv;
-//}
+inline bool Session::push_output_message(dds::xrce::StreamId stream_id, OutputMessagePtr& output_message)
+{
+    bool rv = false;
+    if (128 > stream_id)
+    {
+        besteffort_out_streams_.at(stream_id).promote_stream();
+        rv = true;
+    }
+    else
+    {
+        rv = reliable_out_streams_.at(stream_id).push_message(output_message);
+    }
+    return rv;
+}
 
 inline bool Session::get_output_message(dds::xrce::StreamId stream_id, SeqNum seq_num, OutputMessagePtr& output_message)
 {
@@ -248,21 +246,19 @@ inline void Session::update_from_acknack(const dds::xrce::StreamId stream_id, co
     }
 }
 
-//inline SeqNum Session::next_output_message(const dds::xrce::StreamId stream_id)
-//{
-//    SeqNum rv;
-//    if (128 > stream_id)
-//    {
-//        std::lock_guard<std::mutex> bo_lock(bo_mtx_);
-//        rv = besteffort_out_streams_.at(stream_id).get_last_handled() + 1;
-//    }
-//    else
-//    {
-//        std::lock_guard<std::mutex> ro_lock(ro_mtx_);
-//        rv = reliable_out_streams_.at(stream_id).next_message();
-//    }
-//    return rv;
-//}
+inline SeqNum Session::next_output_message(const dds::xrce::StreamId stream_id)
+{
+    SeqNum rv;
+    if (128 > stream_id)
+    {
+        rv = besteffort_out_streams_.at(stream_id).get_last_handled() + 1;
+    }
+    else
+    {
+        rv = reliable_out_streams_.at(stream_id).next_message();
+    }
+    return rv;
+}
 
 inline std::vector<uint8_t> Session::get_output_streams()
 {

--- a/include/uxr/agent/client/session/Session.hpp
+++ b/include/uxr/agent/client/session/Session.hpp
@@ -30,7 +30,7 @@ public:
     Session(dds::xrce::SessionId session_id, const dds::xrce::ClientKey& client_key)
     {
         /* Create Best-Effort output streams. */
-        for (int i = 1; i <= 127; ++i)
+        for (int i = 0; i <= 127; ++i)
         {
             dds::xrce::StreamId stream_id = dds::xrce::StreamId(i);
             besteffort_out_streams_.emplace(std::piecewise_construct,

--- a/include/uxr/agent/client/session/Session.hpp
+++ b/include/uxr/agent/client/session/Session.hpp
@@ -27,7 +27,7 @@ namespace uxr {
 class Session
 {
 public:
-    Session(dds::xrce::SessionId session_id, const dds::xrce::ClientKey& client_key)
+    Session(dds::xrce::SessionId session_id, const dds::xrce::ClientKey& client_key, size_t mtu)
     {
         /* Create Best-Effort output streams. */
         for (int i = 0; i <= 127; ++i)
@@ -35,7 +35,7 @@ public:
             dds::xrce::StreamId stream_id = dds::xrce::StreamId(i);
             besteffort_out_streams_.emplace(std::piecewise_construct,
                                             std::forward_as_tuple(dds::xrce::StreamId(i)),
-                                            std::forward_as_tuple(session_id, stream_id, client_key));
+                                            std::forward_as_tuple(session_id, stream_id, client_key, mtu));
         }
 
         /* Create Relaible output streams. */
@@ -44,7 +44,7 @@ public:
             dds::xrce::StreamId stream_id = dds::xrce::StreamId(i);
             reliable_out_streams_.emplace(std::piecewise_construct,
                                           std::forward_as_tuple(dds::xrce::StreamId(i)),
-                                          std::forward_as_tuple(session_id, stream_id, client_key));
+                                          std::forward_as_tuple(session_id, stream_id, client_key, mtu));
         }
     }
 

--- a/include/uxr/agent/client/session/Session.hpp
+++ b/include/uxr/agent/client/session/Session.hpp
@@ -200,7 +200,7 @@ inline void Session::push_input_fragment(dds::xrce::StreamId stream_id, InputMes
 
 inline bool Session::pop_input_fragment_message(dds::xrce::StreamId stream_id, InputMessagePtr& message)
 {
-    return reliable_istreams_[stream_id].pop_fragment_message(message);
+    return reliable_in_streams_[stream_id].pop_fragment_message(message);
 }
 
 /**************************************************************************************************

--- a/include/uxr/agent/client/session/stream/InputStream.hpp
+++ b/include/uxr/agent/client/session/stream/InputStream.hpp
@@ -19,6 +19,7 @@
 #include <uxr/agent/message/Packet.hpp>
 #include <uxr/agent/utils/SeqNum.hpp>
 #include <map>
+#include <mutex>
 
 namespace eprosima {
 namespace uxr {
@@ -53,10 +54,12 @@ public:
 
 private:
     SeqNum last_received_;
+    std::mutex mtx_;
 };
 
 inline bool BestEffortInputStream::next_message(SeqNum seq_num)
 {
+    std::lock_guard<std::mutex> lock(mtx_);
     if (seq_num > last_received_)
     {
         last_received_ = seq_num;
@@ -86,7 +89,7 @@ public:
     bool next_message(SeqNum seq_num, InputMessagePtr& message);
     bool pop_message(InputMessagePtr& message);
     void update_from_heartbeat(SeqNum first_available, SeqNum last_available);
-    SeqNum get_first_unacked() const;
+    SeqNum get_first_unacked();
     std::array<uint8_t, 2> get_nack_bitmap();
     void reset();
     void push_fragment(InputMessagePtr& message);
@@ -98,6 +101,7 @@ private:
     std::map<uint16_t, InputMessagePtr> messages_;
     std::vector<uint8_t> fragment_msg_;
     bool fragment_message_available_;
+    std::mutex mtx_;
 };
 
 inline ReliableInputStream::ReliableInputStream(ReliableInputStream&& x)
@@ -118,6 +122,7 @@ inline ReliableInputStream& ReliableInputStream::operator=(ReliableInputStream&&
 inline bool ReliableInputStream::next_message(SeqNum seq_num, InputMessagePtr& message)
 {
     bool rv = false;
+    std::lock_guard<std::mutex> lock(mtx_);
     if (seq_num == last_handled_ + 1)
     {
         last_handled_ += 1;
@@ -148,6 +153,7 @@ inline bool ReliableInputStream::next_message(SeqNum seq_num, InputMessagePtr& m
 inline bool ReliableInputStream::pop_message(InputMessagePtr& message)
 {
     bool rv = false;
+    std::lock_guard<std::mutex> lock(mtx_);
     auto it = messages_.find(last_handled_ + 1);
     if (it != messages_.end())
     {
@@ -161,6 +167,7 @@ inline bool ReliableInputStream::pop_message(InputMessagePtr& message)
 
 inline void ReliableInputStream::update_from_heartbeat(SeqNum first_available, SeqNum last_available)
 {
+    std::lock_guard<std::mutex> lock(mtx_);
     if (last_handled_ + 1 < first_available)
     {
         last_handled_ = first_available;
@@ -171,14 +178,16 @@ inline void ReliableInputStream::update_from_heartbeat(SeqNum first_available, S
     }
 }
 
-inline SeqNum ReliableInputStream::get_first_unacked() const
+inline SeqNum ReliableInputStream::get_first_unacked()
 {
+    std::lock_guard<std::mutex> lock(mtx_);
     return last_handled_ + 1;
 }
 
 inline std::array<uint8_t, 2> ReliableInputStream::get_nack_bitmap()
 {
     std::array<uint8_t, 2> bitmap = {0, 0};
+    std::lock_guard<std::mutex> lock(mtx_);
     for (uint16_t i = 0; i < 8; i++)
     {
         if (last_handled_ + SeqNum(i) < last_announced_)
@@ -203,6 +212,7 @@ inline std::array<uint8_t, 2> ReliableInputStream::get_nack_bitmap()
 
 inline void ReliableInputStream::reset()
 {
+    std::lock_guard<std::mutex> lock(mtx_);
     last_handled_ = ~0;
     last_announced_ = ~0;
     messages_.clear();
@@ -210,6 +220,8 @@ inline void ReliableInputStream::reset()
 
 inline void ReliableInputStream::push_fragment(InputMessagePtr& message)
 {
+    std::lock_guard<std::mutex> lock(mtx_);
+
     /* Add header in case. */
     if (fragment_msg_.empty())
     {
@@ -231,6 +243,7 @@ inline void ReliableInputStream::push_fragment(InputMessagePtr& message)
 inline bool ReliableInputStream::pop_fragment_message(InputMessagePtr& message)
 {
     bool rv = false;
+    std::lock_guard<std::mutex> lock(mtx_);
     if (fragment_message_available_)
     {
         message.reset(new InputMessage(fragment_msg_.data(), fragment_msg_.size()));

--- a/include/uxr/agent/client/session/stream/InputStream.hpp
+++ b/include/uxr/agent/client/session/stream/InputStream.hpp
@@ -24,6 +24,23 @@ namespace eprosima {
 namespace uxr {
 
 /**************************************************************************************************
+ * None Input Streams.
+ **************************************************************************************************/
+class NoneInputStream
+{
+public:
+    NoneInputStream() {}
+
+    bool next_message(SeqNum seq_num);
+};
+
+inline bool NoneInputStream::next_message(SeqNum seq_num)
+{
+    (void) seq_num;
+    return true;
+}
+
+/**************************************************************************************************
  * Best-Effort Input Streams.
  **************************************************************************************************/
 class BestEffortInputStream

--- a/include/uxr/agent/client/session/stream/InputStream.hpp
+++ b/include/uxr/agent/client/session/stream/InputStream.hpp
@@ -47,10 +47,10 @@ inline bool NoneInputStream::next_message(SeqNum seq_num)
 class BestEffortInputStream
 {
 public:
-    BestEffortInputStream() : last_received_(~0) {}
+    BestEffortInputStream() : last_received_(UINT16_MAX) {}
 
     bool next_message(SeqNum seq_num);
-    void reset() { last_received_ = ~0; }
+    void reset() { last_received_ = UINT16_MAX; }
 
 private:
     SeqNum last_received_;
@@ -75,8 +75,8 @@ class ReliableInputStream
 {
 public:
     ReliableInputStream()
-        : last_handled_(~0),
-          last_announced_(~0),
+        : last_handled_(UINT16_MAX),
+          last_announced_(UINT16_MAX),
           fragment_msg_{},
           fragment_message_available_(false)
     {}
@@ -213,8 +213,8 @@ inline std::array<uint8_t, 2> ReliableInputStream::get_nack_bitmap()
 inline void ReliableInputStream::reset()
 {
     std::lock_guard<std::mutex> lock(mtx_);
-    last_handled_ = ~0;
-    last_announced_ = ~0;
+    last_handled_ = UINT16_MAX;
+    last_announced_ = UINT16_MAX;
     messages_.clear();
 }
 

--- a/include/uxr/agent/client/session/stream/OutputStream.hpp
+++ b/include/uxr/agent/client/session/stream/OutputStream.hpp
@@ -209,8 +209,9 @@ inline void ReliableOutputStream::update_from_acknack(SeqNum first_unacked)
 
 inline void ReliableOutputStream::reset()
 {
-    last_acknown_ = ~0;
+    last_available_ = ~0;
     last_sent_ = ~0;
+    last_acknown_ = ~0;
     messages_.clear();
 }
 

--- a/include/uxr/agent/client/session/stream/OutputStream.hpp
+++ b/include/uxr/agent/client/session/stream/OutputStream.hpp
@@ -90,11 +90,13 @@ inline void BestEffortOutputStream::push_submessage(dds::xrce::SubmessageId id, 
 {
     if (BEST_EFFORT_STREAM_DEPTH > messages_.size())
     {
+        last_send_ += 1;
+
         /* Message header. */
         dds::xrce::MessageHeader message_header;
         message_header.session_id(session_id_);
         message_header.stream_id(stream_id_);
-        message_header.sequence_nr(0x0000);
+        message_header.sequence_nr(last_send_);
         message_header.client_key(client_key_);
 
         /* Create message. */

--- a/include/uxr/agent/client/session/stream/OutputStream.hpp
+++ b/include/uxr/agent/client/session/stream/OutputStream.hpp
@@ -106,9 +106,7 @@ public:
           last_send_(UINT16_MAX)
     {}
 
-//    bool push_message(OutputMessagePtr&& output_message);
-//    bool pop_message(OutputMessagePtr& output_message);
-//    SeqNum get_last_handled() const { return last_send_; }
+    SeqNum get_last_handled() const { return last_send_; }
     void promote_stream() { last_send_ += 1; }
     void reset() { last_send_ = UINT16_MAX; }
 
@@ -125,29 +123,6 @@ private:
     std::queue<OutputMessagePtr> messages_;
     std::mutex mtx_;
 };
-
-//inline bool BestEffortOutputStream::push_message(OutputMessagePtr&& output_message)
-//{
-//    bool rv = false;
-//    if (BEST_EFFORT_STREAM_DEPTH > messages_.size())
-//    {
-//        messages_.push(std::move(output_message));
-//        rv = true;
-//    }
-//    return rv;
-//}
-//
-//inline bool BestEffortOutputStream::pop_message(OutputMessagePtr& output_message)
-//{
-//    bool rv = false;
-//    if (!messages_.empty())
-//    {
-//        output_message = std::move(messages_.front());
-//        messages_.pop();
-//        rv = true;
-//    }
-//    return rv;
-//}
 
 template<class T>
 inline void BestEffortOutputStream::push_submessage(dds::xrce::SubmessageId id, const T& submessage)

--- a/include/uxr/agent/client/session/stream/OutputStream.hpp
+++ b/include/uxr/agent/client/session/stream/OutputStream.hpp
@@ -113,6 +113,7 @@ inline bool BestEffortOutputStream::get_next_message(OutputMessagePtr& output_me
     {
         output_message = std::move(messages_.front());
         messages_.pop();
+        rv = true;
     }
     return rv;
 }

--- a/include/uxr/agent/client/session/stream/OutputStream.hpp
+++ b/include/uxr/agent/client/session/stream/OutputStream.hpp
@@ -91,6 +91,7 @@ inline void BestEffortOutputStream::push_submessage(dds::xrce::SubmessageId id, 
         dds::xrce::MessageHeader message_header;
         message_header.session_id(session_id_);
         message_header.stream_id(stream_id_);
+        message_header.sequence_nr(0x0000);
         message_header.client_key(client_key_);
 
         /* Create message. */
@@ -219,10 +220,13 @@ inline void ReliableOutputStream::push_submessage(dds::xrce::SubmessageId id, co
 {
     if (last_available_ < last_acknown_ + SeqNum(RELIABLE_STREAM_DEPTH))
     {
+        last_available_ += 1;
+
         /* Message header. */
         dds::xrce::MessageHeader message_header;
         message_header.session_id(session_id_);
         message_header.stream_id(stream_id_);
+        message_header.sequence_nr(last_available_);
         message_header.client_key(client_key_);
 
         /* Create message. */
@@ -230,7 +234,6 @@ inline void ReliableOutputStream::push_submessage(dds::xrce::SubmessageId id, co
         output_message->append_submessage(id, submessage);
 
         /* Push message. */
-        last_available_ += 1;
         messages_.insert(std::make_pair(last_available_, std::move(output_message)));
     }
 }

--- a/include/uxr/agent/message/OutputMessage.hpp
+++ b/include/uxr/agent/message/OutputMessage.hpp
@@ -30,7 +30,7 @@ class OutputMessage
 {
 public:
     OutputMessage(const dds::xrce::MessageHeader& header, size_t size)
-        : buf_(new uint8_t[size]),
+        : buf_(new uint8_t[size]{0}),
           size_(size),
           fastbuffer_(reinterpret_cast<char*>(buf_), size_),
           serializer_(fastbuffer_)

--- a/include/uxr/agent/message/OutputMessage.hpp
+++ b/include/uxr/agent/message/OutputMessage.hpp
@@ -95,6 +95,9 @@ inline bool OutputMessage::append_raw_payload(dds::xrce::SubmessageId submessage
         rv = false;
     }
 
+    return rv;
+}
+
 inline bool OutputMessage::append_fragment(const dds::xrce::SubmessageHeader& subheader, uint8_t* buf, size_t len)
 {
     bool rv = false;

--- a/include/uxr/agent/types/MessageHeader.hpp
+++ b/include/uxr/agent/types/MessageHeader.hpp
@@ -200,7 +200,7 @@ class MessageHeader
      * @param current_alignment Buffer alignment.
      * @return Serialized size.
      */
-    static size_t getCdrSerializedSize(const MessageHeader& data, size_t current_alignment = 0);
+    size_t getCdrSerializedSize(size_t current_alignment = 0) const;
 
     /*!
      * @brief This function serializes an object using CDR serialization.

--- a/include/uxr/agent/types/SubMessageHeader.hpp
+++ b/include/uxr/agent/types/SubMessageHeader.hpp
@@ -181,8 +181,7 @@ class SubmessageHeader
      * @param current_alignment Buffer alignment.
      * @return Serialized size.
      */
-    static size_t getCdrSerializedSize(const dds::xrce::SubmessageHeader &data,
-                                                               size_t current_alignment = 0);
+    size_t getCdrSerializedSize(size_t current_alignment = 0);
 
     /*!
      * @brief This function serializes an object using CDR serialization.

--- a/include/uxr/agent/types/SubMessageHeader.hpp
+++ b/include/uxr/agent/types/SubMessageHeader.hpp
@@ -35,7 +35,8 @@ namespace xrce {
 
 enum SubmessageHeaderFlags : uint8_t
 {
-    FLAG_ENDIANNESS = 0x01 << 0,
+    FLAG_BIG_ENDIANNESS = 0x00,
+    FLAG_LITTLE_ENDIANNESS = 0x01 << 0,
     FLAG_REUSE = 0x01 << 1,
     FLAG_REPLACE = 0x01 << 2,
     FLAG_LAST_FRAGMENT = 0x01 << 1,

--- a/include/uxr/agent/utils/SeqNum.hpp
+++ b/include/uxr/agent/utils/SeqNum.hpp
@@ -25,7 +25,7 @@ class SeqNum
 public:
     SeqNum() : seq_num_(0) {}
     SeqNum(uint16_t seq_num) : seq_num_(seq_num) {}
-    SeqNum(int seq_num) : seq_num_(static_cast<uint16_t>(seq_num)) {}
+    SeqNum(int seq_num) : seq_num_(uint16_t(seq_num)) {}
 
     /*
      * Operators.

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -538,31 +538,31 @@ bool Processor::process_performance_submessage(ProxyClient& client, InputPacket&
     /* Check ECHO. */
     if (dds::xrce::FLAG_ECHO == (dds::xrce::FLAG_ECHO & input_packet.message->get_subheader().flags()))
     {
-//        /* PERFORMANCE header. */
-//        dds::xrce::MessageHeader output_header;
-//        output_header.session_id(input_packet.message->get_header().session_id());
-//        output_header.stream_id(input_packet.message->get_header().stream_id());
-//        output_header.sequence_nr(client.session().next_output_message(output_header.stream_id()));
-//        output_header.client_key(input_packet.message->get_header().client_key());
-//
-//        /* PERFORMANCE subheader. */
-//        dds::xrce::SubmessageHeader performance_subheader;
-//        performance_subheader.submessage_id(dds::xrce::PERFORMANCE);
-//        performance_subheader.flags(0x01);
-//        performance_subheader.submessage_length(submessage_len);
-//
-//        const size_t message_size = output_header.getCdrSerializedSize() +
-//                                    performance_subheader.getCdrSerializedSize() +
-//                                    submessage_len;
-//
-//        /* Generate output packect. */
-//        output_packet.message = OutputMessagePtr(new OutputMessage(output_header, message_size));
-//        output_packet.message->append_raw_payload(dds::xrce::PERFORMANCE, buf, size_t(submessage_len));
-//        if (client.session().push_output_message(output_header.stream_id(), output_packet.message))
-//        {
-//            /* Send message. */
-//            server_->push_output_packet(output_packet);
-//        }
+        /* PERFORMANCE header. */
+        dds::xrce::MessageHeader output_header;
+        output_header.session_id(input_packet.message->get_header().session_id());
+        output_header.stream_id(input_packet.message->get_header().stream_id());
+        output_header.sequence_nr(client.session().next_output_message(output_header.stream_id()));
+        output_header.client_key(input_packet.message->get_header().client_key());
+
+        /* PERFORMANCE subheader. */
+        dds::xrce::SubmessageHeader performance_subheader;
+        performance_subheader.submessage_id(dds::xrce::PERFORMANCE);
+        performance_subheader.flags(0x01);
+        performance_subheader.submessage_length(submessage_len);
+
+        const size_t message_size = output_header.getCdrSerializedSize() +
+                                    performance_subheader.getCdrSerializedSize() +
+                                    submessage_len;
+
+        /* Generate output packect. */
+        output_packet.message = OutputMessagePtr(new OutputMessage(output_header, message_size));
+        output_packet.message->append_raw_payload(dds::xrce::PERFORMANCE, buf, size_t(submessage_len));
+        if (client.session().push_output_message(output_header.stream_id(), output_packet.message))
+        {
+            /* Send message. */
+            server_->push_output_packet(output_packet);
+        }
     }
     return true;
 }

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -86,10 +86,21 @@ void Processor::process_input_packet(InputPacket&& input_packet)
                 acknack_payload.nack_bitmap(client->session().get_nack_bitmap(stream_id));
                 acknack_payload.stream_id(header.stream_id());
 
+                /* ACKNACK subheader. */
+                dds::xrce::SubmessageHeader acknack_subheader;
+                acknack_subheader.submessage_id(dds::xrce::ACKNACK);
+                acknack_subheader.flags(0x01);
+                acknack_subheader.submessage_length(uint16_t(acknack_payload.getCdrSerializedSize()));
+
+                /* Compute message size. */
+                const size_t message_size = acknack_header.getCdrSerializedSize() +
+                                            acknack_subheader.getCdrSerializedSize() +
+                                            acknack_payload.getCdrSerializedSize();
+
                 /* Set output packet and serialize ACKNACK. */
                 OutputPacket output_packet;
                 output_packet.destination = input_packet.source;
-                output_packet.message.reset(new OutputMessage(acknack_header));
+                output_packet.message.reset(new OutputMessage(acknack_header, message_size));
                 output_packet.message->append_submessage(dds::xrce::ACKNACK, acknack_payload);
 
                 /* Send message. */
@@ -188,8 +199,8 @@ bool Processor::process_create_client_submessage(InputPacket& input_packet)
         if (rv)
         {
             /* STATUS_AGENT header. */
-            dds::xrce::MessageHeader output_header = input_packet.message->get_header();
-            output_header.session_id(client_payload.client_representation().session_id());
+            dds::xrce::MessageHeader status_header = input_packet.message->get_header();
+            status_header.session_id(client_payload.client_representation().session_id());
 
             /* STATUS_AGENT payload. */
             dds::xrce::STATUS_AGENT_Payload status_payload;
@@ -208,10 +219,21 @@ bool Processor::process_create_client_submessage(InputPacket& input_packet)
             status_payload.result(result);
             status_payload.agent_info(agent_representation);
 
+            /* STATUS_AGENT subheader. */
+            dds::xrce::SubmessageHeader status_subheader;
+            status_subheader.submessage_id(dds::xrce::STATUS_AGENT);
+            status_subheader.flags(0x01);
+            status_subheader.submessage_length(uint16_t(status_payload.getCdrSerializedSize()));
+
+            /* Compute message size. */
+            const size_t message_size = status_header.getCdrSerializedSize() +
+                                        status_subheader.getCdrSerializedSize() +
+                                        status_payload.getCdrSerializedSize();
+
             /* Set output packet and serialize STATUS_AGENT. */
             OutputPacket output_packet;
             output_packet.destination = input_packet.source;
-            output_packet.message = std::shared_ptr<OutputMessage>(new OutputMessage(output_header));
+            output_packet.message = std::shared_ptr<OutputMessage>(new OutputMessage(status_header, message_size));
             output_packet.message->append_submessage(dds::xrce::STATUS_AGENT, status_payload);
 
             /* Send message. */
@@ -592,15 +614,28 @@ bool Processor::process_get_info_packet(InputPacket&& input_packet,
                 info_variant.agent(agent_info);
                 object_info.activity(info_variant);
 
+                /* INFO payload. */
                 dds::xrce::INFO_Payload info_payload;
                 info_payload.related_request().request_id(get_info_payload.request_id());
                 info_payload.related_request().object_id(get_info_payload.object_id());
                 info_payload.result(result_status);
                 info_payload.object_info(object_info);
 
+                /* INFO subheader. */
+                dds::xrce::SubmessageHeader info_subheader;
+                info_subheader.submessage_id(dds::xrce::INFO);
+                info_subheader.flags(0x01);
+                info_subheader.submessage_length(uint16_t(info_payload.getCdrSerializedSize()));
+
+                /* Compute message size. */
+                const size_t message_size = input_packet.message->get_header().getCdrSerializedSize() +
+                                            info_subheader.getCdrSerializedSize() +
+                                            info_payload.getCdrSerializedSize();
+
                 /* Set output packet and serialize INFO. */
                 output_packet.destination = input_packet.source;
-                output_packet.message = OutputMessagePtr(new OutputMessage(input_packet.message->get_header()));
+                output_packet.message = OutputMessagePtr(new OutputMessage(input_packet.message->get_header(),
+                                                                           message_size));
                 rv = output_packet.message->append_submessage(dds::xrce::INFO, info_payload);
             }
         }
@@ -621,25 +656,36 @@ void Processor::check_heartbeats()
             /* Get and send pending messages. */
             if (client->session().message_pending(stream))
             {
-                /* Heartbeat message header. */
+                /* HEARTBEAT header. */
                 dds::xrce::MessageHeader heartbeat_header;
                 heartbeat_header.session_id(client->get_session_id());
                 heartbeat_header.stream_id(0x00);
                 heartbeat_header.sequence_nr(0x00);
                 heartbeat_header.client_key(client->get_client_key());
 
-                /* Heartbeat message payload. */
+                /* HEARTBEAT payload. */
                 dds::xrce::HEARTBEAT_Payload heartbeat_payload;
                 heartbeat_payload.first_unacked_seq_nr(client->session().get_first_unacked_seq_nr(stream));
                 heartbeat_payload.last_unacked_seq_nr(client->session().get_last_unacked_seq_nr(stream));
                 heartbeat_payload.stream_id(stream);
+
+                /* HEARTBEAT subheader. */
+                dds::xrce::SubmessageHeader heartbeat_subheader;
+                heartbeat_subheader.submessage_id(dds::xrce::HEARTBEAT);
+                heartbeat_subheader.flags(0x01);
+                heartbeat_subheader.submessage_length(uint16_t(heartbeat_payload.getCdrSerializedSize()));
+
+                /* Compute message size. */
+                const size_t message_size = heartbeat_header.getCdrSerializedSize() +
+                                            heartbeat_subheader.getCdrSerializedSize() +
+                                            heartbeat_payload.getCdrSerializedSize();
 
                 /* Set output packet and serialize HEARTBEAT. */
                 OutputPacket output_packet;
                 output_packet.destination = server_->get_source(client->get_client_key());
                 if (output_packet.destination)
                 {
-                    output_packet.message = OutputMessagePtr(new OutputMessage(heartbeat_header));
+                    output_packet.message = OutputMessagePtr(new OutputMessage(heartbeat_header, message_size));
                     output_packet.message->append_submessage(dds::xrce::HEARTBEAT, heartbeat_payload);
 
                     /* Send message. */

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -542,7 +542,7 @@ bool Processor::process_performance_submessage(ProxyClient& client, InputPacket&
         dds::xrce::MessageHeader output_header;
         output_header.session_id(input_packet.message->get_header().session_id());
         output_header.stream_id(input_packet.message->get_header().stream_id());
-        output_header.sequence_nr(client.session().next_output_message(output_header.stream_id()));
+//        output_header.sequence_nr(client.session().next_output_message(output_header.stream_id()));
         output_header.client_key(input_packet.message->get_header().client_key());
 
         /* PERFORMANCE subheader. */
@@ -556,7 +556,7 @@ bool Processor::process_performance_submessage(ProxyClient& client, InputPacket&
                                     submessage_len;
 
         /* Generate output packect. */
-        output_packet.message = OutputMessagePtr(new OutputMessage(output_header, sizeof(message_size)));
+        output_packet.message = OutputMessagePtr(new OutputMessage(output_header, message_size));
         output_packet.message->append_raw_payload(dds::xrce::PERFORMANCE, buf, size_t(submessage_len));
         if (client.session().push_output_message(output_header.stream_id(), output_packet.message))
         {

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -58,7 +58,7 @@ void Processor::process_input_packet(InputPacket&& input_packet)
             /* Check whether it is the next message. */
             Session& session = client->session();
             dds::xrce::StreamId stream_id = input_packet.message->get_header().stream_id();
-            if (session.next_input_message(input_packet.message))
+            if (session.is_next_input_message(input_packet.message))
             {
                 /* Process messages. */
                 process_input_message(*client, input_packet);
@@ -71,7 +71,7 @@ void Processor::process_input_packet(InputPacket&& input_packet)
             }
 
             /* Send acknack in case. */
-            if (127 < stream_id)
+            if (is_reliable_stream(stream_id))
             {
                 /* ACKNACK header. */
                 dds::xrce::MessageHeader acknack_header;
@@ -538,31 +538,31 @@ bool Processor::process_performance_submessage(ProxyClient& client, InputPacket&
     /* Check ECHO. */
     if (dds::xrce::FLAG_ECHO == (dds::xrce::FLAG_ECHO & input_packet.message->get_subheader().flags()))
     {
-        /* PERFORMANCE header. */
-        dds::xrce::MessageHeader output_header;
-        output_header.session_id(input_packet.message->get_header().session_id());
-        output_header.stream_id(input_packet.message->get_header().stream_id());
+//        /* PERFORMANCE header. */
+//        dds::xrce::MessageHeader output_header;
+//        output_header.session_id(input_packet.message->get_header().session_id());
+//        output_header.stream_id(input_packet.message->get_header().stream_id());
 //        output_header.sequence_nr(client.session().next_output_message(output_header.stream_id()));
-        output_header.client_key(input_packet.message->get_header().client_key());
-
-        /* PERFORMANCE subheader. */
-        dds::xrce::SubmessageHeader performance_subheader;
-        performance_subheader.submessage_id(dds::xrce::PERFORMANCE);
-        performance_subheader.flags(0x01);
-        performance_subheader.submessage_length(submessage_len);
-
-        const size_t message_size = output_header.getCdrSerializedSize() +
-                                    performance_subheader.getCdrSerializedSize() +
-                                    submessage_len;
-
-        /* Generate output packect. */
-        output_packet.message = OutputMessagePtr(new OutputMessage(output_header, message_size));
-        output_packet.message->append_raw_payload(dds::xrce::PERFORMANCE, buf, size_t(submessage_len));
-        if (client.session().push_output_message(output_header.stream_id(), output_packet.message))
-        {
-            /* Send message. */
-            server_->push_output_packet(output_packet);
-        }
+//        output_header.client_key(input_packet.message->get_header().client_key());
+//
+//        /* PERFORMANCE subheader. */
+//        dds::xrce::SubmessageHeader performance_subheader;
+//        performance_subheader.submessage_id(dds::xrce::PERFORMANCE);
+//        performance_subheader.flags(0x01);
+//        performance_subheader.submessage_length(submessage_len);
+//
+//        const size_t message_size = output_header.getCdrSerializedSize() +
+//                                    performance_subheader.getCdrSerializedSize() +
+//                                    submessage_len;
+//
+//        /* Generate output packect. */
+//        output_packet.message = OutputMessagePtr(new OutputMessage(output_header, message_size));
+//        output_packet.message->append_raw_payload(dds::xrce::PERFORMANCE, buf, size_t(submessage_len));
+//        if (client.session().push_output_message(output_header.stream_id(), output_packet.message))
+//        {
+//            /* Send message. */
+//            server_->push_output_packet(output_packet);
+//        }
     }
     return true;
 }

--- a/src/cpp/types/MessageHeader.cpp
+++ b/src/cpp/types/MessageHeader.cpp
@@ -82,29 +82,22 @@ size_t MessageHeader::getMaxCdrSerializedSize(size_t current_alignment)
     size_t initial_alignment = current_alignment;
 
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-
     current_alignment += 2 + eprosima::fastcdr::Cdr::alignment(current_alignment, 2);
-
     current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
 
     return current_alignment - initial_alignment;
 }
 
-size_t MessageHeader::getCdrSerializedSize(const MessageHeader &data,
-                                           size_t current_alignment)
+size_t MessageHeader::getCdrSerializedSize(size_t current_alignment) const
 {
-    // TODO.
-    (void) data;
-
     size_t initial_alignment = current_alignment;
 
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += 2 + eprosima::fastcdr::Cdr::alignment(current_alignment, 2);
 
-    if (128 > data.session_id())
+    if (128 > m_session_id)
     {
         current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     }

--- a/src/cpp/types/SubMessageHeader.cpp
+++ b/src/cpp/types/SubMessageHeader.cpp
@@ -81,28 +81,19 @@ size_t dds::xrce::SubmessageHeader::getMaxCdrSerializedSize(size_t current_align
     size_t initial_alignment = current_alignment;
             
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-
     current_alignment += 2 + eprosima::fastcdr::Cdr::alignment(current_alignment, 2);
-
 
     return current_alignment - initial_alignment;
 }
 
-size_t dds::xrce::SubmessageHeader::getCdrSerializedSize(const dds::xrce::SubmessageHeader& data, size_t current_alignment)
+size_t dds::xrce::SubmessageHeader::getCdrSerializedSize(size_t current_alignment)
 {
-    // TODO.
-    (void) data;
-
     size_t initial_alignment = current_alignment;
             
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-
     current_alignment += 2 + eprosima::fastcdr::Cdr::alignment(current_alignment, 2);
-
 
     return current_alignment - initial_alignment;
 }

--- a/test/integration/cross_serialization/AgentSerialization.cpp
+++ b/test/integration/cross_serialization/AgentSerialization.cpp
@@ -20,8 +20,10 @@ dds::xrce::MessageHeader generate_message_header()
 
 std::vector<uint8_t> AgentSerialization::create_client_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::CREATE_CLIENT_Payload payload;
     payload.request_id() = {0x01, 0x23};
     payload.object_id() = {0x45, 0x67};
@@ -32,6 +34,19 @@ std::vector<uint8_t> AgentSerialization::create_client_payload()
     payload.client_representation().client_timestamp().nanoseconds() = 0x01234567;
     payload.client_representation().client_key() = {0x89, 0xAB, 0xCD, 0xEF};
     payload.client_representation().session_id() = 0x01;
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::CREATE_CLIENT);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::CREATE_CLIENT, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -42,8 +57,10 @@ std::vector<uint8_t> AgentSerialization::create_client_payload()
 
 std::vector<uint8_t> AgentSerialization::create_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::CREATE_Payload payload;
     payload.request_id() = {0x01, 0x23};
     payload.object_id() = {0x45, 0x67};
@@ -51,6 +68,19 @@ std::vector<uint8_t> AgentSerialization::create_payload()
     payload.object_representation().participant().representation()._d() = dds::xrce::REPRESENTATION_BY_REFERENCE;
     payload.object_representation().participant().representation().object_reference() = "ABCDE";
     payload.object_representation().participant().domain_id() = (uint16_t)0x09AB;
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::CREATE);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::CREATE, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -61,12 +91,27 @@ std::vector<uint8_t> AgentSerialization::create_payload()
 
 std::vector<uint8_t> AgentSerialization::get_info_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::GET_INFO_Payload payload;
     payload.request_id() = {0x01, 0x23};
     payload.object_id() = {0x45, 0x67};
     payload.info_mask() = (dds::xrce::InfoMask)0x89ABCDEF;
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::GET_INFO);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::GET_INFO, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -77,11 +122,26 @@ std::vector<uint8_t> AgentSerialization::get_info_payload()
 
 std::vector<uint8_t> AgentSerialization::delete_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::DELETE_Payload payload;
     payload.request_id() = {0x01, 0x23};
     payload.object_id() = {0x45, 0x67};
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::DELETE_ID);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::DELETE_ID, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -92,8 +152,10 @@ std::vector<uint8_t> AgentSerialization::delete_payload()
 
 std::vector<uint8_t> AgentSerialization::status_agent_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::STATUS_AGENT_Payload payload;
     payload.related_request().request_id() = {0x01, 0x23};
     payload.related_request().object_id() = {0x45, 0x67};
@@ -104,6 +166,19 @@ std::vector<uint8_t> AgentSerialization::status_agent_payload()
     time.seconds(0x89ABCDEF);
     time.nanoseconds(0x01234567);
     payload.agent_info().agent_timestamp(time);
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::STATUS_AGENT);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::STATUS_AGENT, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -114,13 +189,28 @@ std::vector<uint8_t> AgentSerialization::status_agent_payload()
 
 std::vector<uint8_t> AgentSerialization::status_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::STATUS_Payload payload;
     payload.related_request().request_id() = {0x01, 0x23};
     payload.related_request().object_id() = {0x45, 0x67};
     payload.result().implementation_status() = 0x89;
     payload.result().status() = (dds::xrce::StatusValue)0xAB;
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::STATUS);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::STATUS, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -131,8 +221,10 @@ std::vector<uint8_t> AgentSerialization::status_payload()
 
 std::vector<uint8_t> AgentSerialization::info_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::TransportAddressMedium medium;
     medium.address() = {0x01, 0x23, 0x45, 0x67};
     medium.port() = 0x0123;
@@ -166,6 +258,19 @@ std::vector<uint8_t> AgentSerialization::info_payload()
     payload.result().status() = (dds::xrce::StatusValue)0xAB;
     payload.object_info().activity(activity);
     payload.object_info().config(config);
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::INFO);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::INFO, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -176,8 +281,10 @@ std::vector<uint8_t> AgentSerialization::info_payload()
 
 std::vector<uint8_t> AgentSerialization::read_data_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::READ_DATA_Payload payload;
     payload.request_id() = {0x01, 0x23};
     payload.object_id() = {0x45, 0x67};
@@ -191,6 +298,19 @@ std::vector<uint8_t> AgentSerialization::read_data_payload()
     delivery_control.min_pace_period() = 0xEF01;
     payload.read_specification().delivery_control(delivery_control);
     payload.read_specification().content_filter_expression("ABCDE");
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::READ_DATA);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::READ_DATA, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -201,12 +321,27 @@ std::vector<uint8_t> AgentSerialization::read_data_payload()
 
 std::vector<uint8_t> AgentSerialization::write_data_payload_data()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::WRITE_DATA_Payload_Data payload;
     payload.request_id() = {0x01, 0x23};
     payload.object_id() = {0x45, 0x67};
     payload.data().serialized_data() = {'B', 'Y', 'T', 'E', 'S'};
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::WRITE_DATA);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::WRITE_DATA, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -241,12 +376,27 @@ std::vector<uint8_t> AgentSerialization::write_data_payload_packed_samples()
 
 std::vector<uint8_t> AgentSerialization::data_payload_data()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::DATA_Payload_Data payload;
     payload.request_id() = {0x01, 0x23};
     payload.object_id() = {0x45, 0x67};
     payload.data().serialized_data() = {'B', 'Y', 'T', 'E', 'S'};
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::DATA);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::DATA, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -281,12 +431,27 @@ std::vector<uint8_t> AgentSerialization::data_payload_packed_samples()
 
 std::vector<uint8_t> AgentSerialization::acknack_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::ACKNACK_Payload payload;
     payload.first_unacked_seq_num() = (uint16_t)0x0123;
     payload.nack_bitmap() = {0x45, 0x67};
     payload.stream_id() = (uint8_t)0x89;
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::ACKNACK);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::ACKNACK, payload, 0x0001);
 
     std::vector<uint8_t> buffer;
@@ -297,12 +462,27 @@ std::vector<uint8_t> AgentSerialization::acknack_payload()
 
 std::vector<uint8_t> AgentSerialization::heartbeat_payload()
 {
-    eprosima::uxr::OutputMessage output(generate_message_header());
+    /* Header. */
+    dds::xrce::MessageHeader header = generate_message_header();
 
+    /* Payload. */
     dds::xrce::HEARTBEAT_Payload payload;
     payload.first_unacked_seq_nr() = (uint16_t)0x0123;
     payload.last_unacked_seq_nr() = (uint16_t)0x4567;
     payload.stream_id() = (uint8_t)0x89;
+
+    /* Subheader. */
+    dds::xrce::SubmessageHeader subheader;
+    subheader.submessage_id(dds::xrce::HEARTBEAT);
+    subheader.flags(0x01);
+    subheader.submessage_length(uint16_t(payload.getCdrSerializedSize()));
+
+    /* Message size. */
+    size_t message_size = header.getCdrSerializedSize() +
+                          subheader.getCdrSerializedSize() +
+                          payload.getCdrSerializedSize();
+
+    eprosima::uxr::OutputMessage output(header, message_size);
     output.append_submessage(dds::xrce::HEARTBEAT, payload, 0x0001);
 
     std::vector<uint8_t> buffer;

--- a/test/integration/cross_serialization/AgentSerialization.cpp
+++ b/test/integration/cross_serialization/AgentSerialization.cpp
@@ -34,6 +34,7 @@ std::vector<uint8_t> AgentSerialization::create_client_payload()
     payload.client_representation().client_timestamp().nanoseconds() = 0x01234567;
     payload.client_representation().client_key() = {0x89, 0xAB, 0xCD, 0xEF};
     payload.client_representation().session_id() = 0x01;
+    payload.client_representation().mtu() = 0x2345;
 
     /* Subheader. */
     dds::xrce::SubmessageHeader subheader;


### PR DESCRIPTION
This pull request adds support for output message fragmentation (from Agent to Client).

This new feature has involved the following changes:

- `OutputStream` class has been modified adding `push_submessage` and `get_next_message` functions.
- `OutputMessage` class has been modified adding `append_fragment` function.
- `Processor` class has been adapted to new `push_submessage` and `get_next_message` functions come from `OutputStream`.