### PR TITLE
Time synchronization [5170]

### DIFF
--- a/include/uxr/agent/processor/Processor.hpp
+++ b/include/uxr/agent/processor/Processor.hpp
@@ -102,6 +102,10 @@ private:
             ProxyClient& client,
             InputPacket& input_packet);
 
+    bool process_timestamp_submessage(
+            ProxyClient& client,
+            InputPacket& input_packet);
+
 //    bool process_performance_submessage(
 //            ProxyClient& client,
 //            InputPacket& input_packet);

--- a/include/uxr/agent/types/XRCETypes.hpp
+++ b/include/uxr/agent/types/XRCETypes.hpp
@@ -10409,6 +10409,300 @@ private:
 };
 
 /*!
+ * @brief This class represents the structure TIMESTAMP_Payload defined by the user in the IDL file.
+ * @ingroup TYPESMOD
+ */
+class TIMESTAMP_Payload
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    TIMESTAMP_Payload();
+
+    /*!
+     * @brief Default destructor.
+     */
+    ~TIMESTAMP_Payload();
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object TIMESTAMP_Payload that will be copied.
+     */
+    TIMESTAMP_Payload(const TIMESTAMP_Payload &x);
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object TIMESTAMP_Payload that will be copied.
+     */
+    TIMESTAMP_Payload(TIMESTAMP_Payload &&x);
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object TIMESTAMP_Payload that will be copied.
+     */
+    TIMESTAMP_Payload& operator=(const TIMESTAMP_Payload &x);
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object TIMESTAMP_Payload that will be copied.
+     */
+    TIMESTAMP_Payload& operator=(TIMESTAMP_Payload &&x);
+
+    /*!
+     * @brief This function sets a value in member transmit_timestamp
+     * @param _transmit_timestamp New value for member transmit_timestamp
+     */
+    inline void transmit_timestamp(const Time_t& _transmit_timestamp)
+    {
+        m_transmit_timestamp = _transmit_timestamp;
+    }
+
+    /*!
+     * @brief This function moves the value in member transmit_timestamp
+     * @param _packed_samples New value to be moved in member transmit_timestamp
+     */
+    inline void transmit_timestamp(Time_t &&_transmit_timestamp)
+    {
+        m_transmit_timestamp = std::move(_transmit_timestamp);
+    }
+
+    /*!
+     * @brief This function returns the value of member transmit_timestamp
+     * @return Value of member transmit_timestamp
+     */
+    inline const Time_t& transmit_timestamp() const
+    {
+        return m_transmit_timestamp;
+    }
+
+    /*!
+     * @brief This function returns a reference to member transmit_timestamp
+     * @return Reference to member transmit_timestamp
+     */
+    inline Time_t& transmit_timestamp()
+    {
+        return m_transmit_timestamp;
+    }
+
+    /*!
+     * @brief This function returns the maximum serialized size of an object
+     * depending on the buffer alignment.
+     * @param current_alignment Buffer alignment.
+     * @return Maximum serialized size.
+     */
+    static size_t getMaxCdrSerializedSize(size_t current_alignment = 0);
+
+    /*!
+     * @brief This function returns the serialized size of a data depending on the buffer alignment.
+     * @param data Data which is calculated its serialized size.
+     * @param current_alignment Buffer alignment.
+     * @return Serialized size.
+     */
+    virtual size_t getCdrSerializedSize(size_t current_alignment = 0) const;
+
+    /*!
+     * @brief This function serializes an object using CDR serialization.
+     * @param cdr CDR serialization object.
+     */
+    virtual void serialize(eprosima::fastcdr::Cdr &cdr) const;
+
+    /*!
+     * @brief This function deserializes an object using CDR serialization.
+     * @param cdr CDR serialization object.
+     */
+    virtual void deserialize(eprosima::fastcdr::Cdr &cdr);
+
+private:
+    Time_t m_transmit_timestamp;
+};
+
+/*!
+ * @brief This class represents the structure TIMESTAMP_Payload defined by the user in the IDL file.
+ * @ingroup TYPESMOD
+ */
+class TIMESTAMP_REPLY_Payload
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    TIMESTAMP_REPLY_Payload();
+
+    /*!
+     * @brief Default destructor.
+     */
+    ~TIMESTAMP_REPLY_Payload();
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object TIMESTAMP_REPLY_Payload that will be copied.
+     */
+    TIMESTAMP_REPLY_Payload(const TIMESTAMP_REPLY_Payload &x);
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object TIMESTAMP_REPLY_Payload that will be copied.
+     */
+    TIMESTAMP_REPLY_Payload(TIMESTAMP_REPLY_Payload &&x);
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object TIMESTAMP_REPLY_Payload that will be copied.
+     */
+    TIMESTAMP_REPLY_Payload& operator=(const TIMESTAMP_REPLY_Payload &x);
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object TIMESTAMP_REPLY_Payload that will be copied.
+     */
+    TIMESTAMP_REPLY_Payload& operator=(TIMESTAMP_REPLY_Payload &&x);
+
+    /*!
+     * @brief This function sets a value in member transmit_timestamp
+     * @param _transmit_timestamp New value for member transmit_timestamp
+     */
+    inline void transmit_timestamp(const Time_t& _transmit_timestamp)
+    {
+        m_transmit_timestamp = _transmit_timestamp;
+    }
+
+    /*!
+     * @brief This function moves the value in member transmit_timestamp
+     * @param _packed_samples New value to be moved in member transmit_timestamp
+     */
+    inline void transmit_timestamp(Time_t &&_transmit_timestamp)
+    {
+        m_transmit_timestamp = std::move(_transmit_timestamp);
+    }
+
+    /*!
+     * @brief This function returns the value of member transmit_timestamp
+     * @return Value of member transmit_timestamp
+     */
+    inline const Time_t& transmit_timestamp() const
+    {
+        return m_transmit_timestamp;
+    }
+
+    /*!
+     * @brief This function returns a reference to member transmit_timestamp
+     * @return Reference to member transmit_timestamp
+     */
+    inline Time_t& transmit_timestamp()
+    {
+        return m_transmit_timestamp;
+    }
+
+    /*!
+     * @brief This function sets a value in member receive_timestamp
+     * @param _receive_timestamp New value for member receive_timestamp
+     */
+    inline void receive_timestamp(const Time_t& _receive_timestamp)
+    {
+        m_receive_timestamp = _receive_timestamp;
+    }
+
+    /*!
+     * @brief This function moves the value in member receive_timestamp
+     * @param _packed_samples New value to be moved in member receive_timestamp
+     */
+    inline void receive_timestamp(Time_t &&_receive_timestamp)
+    {
+        m_receive_timestamp = std::move(_receive_timestamp);
+    }
+
+    /*!
+     * @brief This function returns the value of member receive_timestamp
+     * @return Value of member receive_timestamp
+     */
+    inline const Time_t& receive_timestamp() const
+    {
+        return m_receive_timestamp;
+    }
+
+    /*!
+     * @brief This function returns a reference to member receive_timestamp
+     * @return Reference to member receive_timestamp
+     */
+    inline Time_t& receive_timestamp()
+    {
+        return m_receive_timestamp;
+    }
+
+    /*!
+     * @brief This function sets a value in member originate_timestamp
+     * @param _originate_timestamp New value for member originate_timestamp
+     */
+    inline void originate_timestamp(const Time_t& _originate_timestamp)
+    {
+        m_originate_timestamp = _originate_timestamp;
+    }
+
+    /*!
+     * @brief This function moves the value in member originate_timestamp
+     * @param _packed_samples New value to be moved in member originate_timestamp
+     */
+    inline void originate_timestamp(Time_t &&_originate_timestamp)
+    {
+        m_originate_timestamp = std::move(_originate_timestamp);
+    }
+
+    /*!
+     * @brief This function returns the value of member originate_timestamp
+     * @return Value of member originate_timestamp
+     */
+    inline const Time_t& originate_timestamp() const
+    {
+        return m_originate_timestamp;
+    }
+
+    /*!
+     * @brief This function returns a reference to member originate_timestamp
+     * @return Reference to member originate_timestamp
+     */
+    inline Time_t& originate_timestamp()
+    {
+        return m_originate_timestamp;
+    }
+
+    /*!
+     * @brief This function returns the maximum serialized size of an object
+     * depending on the buffer alignment.
+     * @param current_alignment Buffer alignment.
+     * @return Maximum serialized size.
+     */
+    static size_t getMaxCdrSerializedSize(size_t current_alignment = 0);
+
+    /*!
+     * @brief This function returns the serialized size of a data depending on the buffer alignment.
+     * @param data Data which is calculated its serialized size.
+     * @param current_alignment Buffer alignment.
+     * @return Serialized size.
+     */
+    virtual size_t getCdrSerializedSize(size_t current_alignment = 0) const;
+
+    /*!
+     * @brief This function serializes an object using CDR serialization.
+     * @param cdr CDR serialization object.
+     */
+    virtual void serialize(eprosima::fastcdr::Cdr &cdr) const;
+
+    /*!
+     * @brief This function deserializes an object using CDR serialization.
+     * @param cdr CDR serialization object.
+     */
+    virtual void deserialize(eprosima::fastcdr::Cdr &cdr);
+
+private:
+    Time_t m_transmit_timestamp;
+    Time_t m_receive_timestamp;
+    Time_t m_originate_timestamp;
+};
+
+/*!
  * @brief This class represents the enumeration SubmessageId defined by the user in the IDL file.
  * @ingroup TYPESMOD
  */
@@ -10428,7 +10722,9 @@ enum SubmessageId : uint8_t
     HEARTBEAT       = 11,
     RESET           = 12,
     FRAGMENT        = 13,
-    PERFORMANCE     = 14
+    TIMESTAMP       = 14,
+    TIMESTAMP_REPLY = 15,
+    PERFORMANCE     = 255
 };
 
 } } // namespace 

--- a/include/uxr/agent/types/XRCETypes.hpp
+++ b/include/uxr/agent/types/XRCETypes.hpp
@@ -6899,30 +6899,30 @@ public:
     ReadSpecification& operator=(ReadSpecification &&x);
 
     /*!
-     * @brief This function sets a value in member data_stream_id
-     * @param _data_stream_id New value for member data_stream_id
+     * @brief This function sets a value in member preferred_stream_id
+     * @param _preferred_stream_id New value for member preferred_stream_id
      */
-    inline void data_stream_id(StreamId _data_stream_id)
+    inline void preferred_stream_id(StreamId _preferred_stream_id)
     {
-        m_data_stream_id = _data_stream_id;
+        m_preferred_stream_id = _preferred_stream_id;
     }
 
     /*!
-     * @brief This function returns the value of member data_stream_id
-     * @return Value of member data_stream_id
+     * @brief This function returns the value of member preferred_stream_id
+     * @return Value of member preferred_stream_id
      */
-    inline StreamId data_stream_id() const
+    inline StreamId preferred_stream_id() const
     {
-        return m_data_stream_id;
+        return m_preferred_stream_id;
     }
 
     /*!
-     * @brief This function returns a reference to member data_stream_id
-     * @return Reference to member data_stream_id
+     * @brief This function returns a reference to member preferred_stream_id
+     * @return Reference to member preferred_stream_id
      */
-    inline StreamId& data_stream_id()
+    inline StreamId& preferred_stream_id()
     {
-        return m_data_stream_id;
+        return m_preferred_stream_id;
     }
 
     /*!
@@ -7079,7 +7079,7 @@ public:
     virtual void deserialize(eprosima::fastcdr::Cdr &cdr);
 
 private:
-    StreamId m_data_stream_id;
+    StreamId m_preferred_stream_id;
     DataFormat m_data_format;
     eprosima::Optional<std::string> m_content_filter_expression;
     eprosima::Optional<DataDeliveryControl> m_delivery_control;
@@ -10461,7 +10461,7 @@ public:
 
     /*!
      * @brief This function moves the value in member transmit_timestamp
-     * @param _packed_samples New value to be moved in member transmit_timestamp
+     * @param _transmit_timestamp New value to be moved in member transmit_timestamp
      */
     inline void transmit_timestamp(Time_t &&_transmit_timestamp)
     {
@@ -10571,7 +10571,7 @@ public:
 
     /*!
      * @brief This function moves the value in member transmit_timestamp
-     * @param _packed_samples New value to be moved in member transmit_timestamp
+     * @param _transmit_timestamp New value to be moved in member transmit_timestamp
      */
     inline void transmit_timestamp(Time_t &&_transmit_timestamp)
     {
@@ -10607,7 +10607,7 @@ public:
 
     /*!
      * @brief This function moves the value in member receive_timestamp
-     * @param _packed_samples New value to be moved in member receive_timestamp
+     * @param _receive_timestamp New value to be moved in member receive_timestamp
      */
     inline void receive_timestamp(Time_t &&_receive_timestamp)
     {
@@ -10643,7 +10643,7 @@ public:
 
     /*!
      * @brief This function moves the value in member originate_timestamp
-     * @param _packed_samples New value to be moved in member originate_timestamp
+     * @param _originate_timestamp New value to be moved in member originate_timestamp
      */
     inline void originate_timestamp(Time_t &&_originate_timestamp)
     {

--- a/include/uxr/agent/types/XRCETypes.hpp
+++ b/include/uxr/agent/types/XRCETypes.hpp
@@ -8554,8 +8554,44 @@ public:
      * @param x Reference to the object STATUS_AGENT_Payload that will be copied.
      */
     STATUS_AGENT_Payload& operator=(STATUS_AGENT_Payload &&x);
-    
+
+    /*
+     * @brief This function copies the value in member result
+     * @param _retuls New value to be copied in member result
+     */
+    inline void result(const ResultStatus &_result)
+    {
+        m_result = _result;
+    }
+
     /*!
+     * @brief This function moves the value in member result
+     * @param _result New value to be moved in member result
+     */
+    inline void result(ResultStatus &&_result)
+    {
+        m_result = std::move(_result);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member result
+     * @return Constant reference to member result
+     */
+    inline const ResultStatus& result() const
+    {
+        return m_result;
+    }
+
+    /*!
+     * @brief This function returns a reference to member result
+     * @return Reference to member result
+     */
+    inline ResultStatus& result()
+    {
+        return m_result;
+    }
+
+    /*
      * @brief This function copies the value in member agent_info
      * @param _agent_info New value to be copied in member agent_info
      */
@@ -8620,6 +8656,7 @@ public:
     virtual void deserialize(eprosima::fastcdr::Cdr &cdr);
 
 private:
+    ResultStatus m_result;
     AGENT_Representation m_agent_info;
 };
 

--- a/include/uxr/agent/types/XRCETypes.hpp
+++ b/include/uxr/agent/types/XRCETypes.hpp
@@ -1248,41 +1248,7 @@ public:
     {
         return m_xrce_vendor_id;
     }
-    /*!
-     * @brief This function copies the value in member client_timestamp
-     * @param _client_timestamp New value to be copied in member client_timestamp
-     */
-    inline void client_timestamp(const Time_t &_client_timestamp)
-    {
-        m_client_timestamp = _client_timestamp;
-    }
 
-    /*!
-     * @brief This function moves the value in member client_timestamp
-     * @param _client_timestamp New value to be moved in member client_timestamp
-     */
-    inline void client_timestamp(Time_t &&_client_timestamp)
-    {
-        m_client_timestamp = std::move(_client_timestamp);
-    }
-
-    /*!
-     * @brief This function returns a constant reference to member client_timestamp
-     * @return Constant reference to member client_timestamp
-     */
-    inline const Time_t& client_timestamp() const
-    {
-        return m_client_timestamp;
-    }
-
-    /*!
-     * @brief This function returns a reference to member client_timestamp
-     * @return Reference to member client_timestamp
-     */
-    inline Time_t& client_timestamp()
-    {
-        return m_client_timestamp;
-    }
     /*!
      * @brief This function copies the value in member client_key
      * @param _client_key New value to be copied in member client_key
@@ -1432,7 +1398,6 @@ private:
     XrceCookie m_xrce_cookie;
     XrceVersion m_xrce_version;
     XrceVendorId m_xrce_vendor_id;
-    Time_t m_client_timestamp;
     ClientKey m_client_key;
     SessionId m_session_id;
     eprosima::Optional<PropertySeq> m_properties;
@@ -1588,42 +1553,6 @@ public:
     }
 
     /*!
-     * @brief This function copies the value in member agent_timestamp
-     * @param _agent_timestamp New value to be copied in member agent_timestamp
-     */
-    inline void agent_timestamp(const Time_t &_agent_timestamp)
-    {
-        m_agent_timestamp = _agent_timestamp;
-    }
-
-    /*!
-     * @brief This function moves the value in member agent_timestamp
-     * @param _agent_timestamp New value to be moved in member agent_timestamp
-     */
-    inline void agent_timestamp(Time_t &&_agent_timestamp)
-    {
-        m_agent_timestamp = std::move(_agent_timestamp);
-    }
-
-    /*!
-     * @brief This function returns a constant reference to member agent_timestamp
-     * @return Constant reference to member agent_timestamp
-     */
-    inline const Time_t& agent_timestamp() const
-    {
-        return m_agent_timestamp;
-    }
-
-    /*!
-     * @brief This function returns a reference to member agent_timestamp
-     * @return Reference to member agent_timestamp
-     */
-    inline Time_t& agent_timestamp()
-    {
-        return m_agent_timestamp;
-    }
-
-    /*!
      * @brief This function sets a value in member properties
      * @param _properties New value for member properties
      */
@@ -1683,7 +1612,6 @@ private:
     XrceCookie m_xrce_cookie;
     XrceVersion m_xrce_version;
     XrceVendorId m_xrce_vendor_id;
-    Time_t m_agent_timestamp;
     eprosima::Optional<PropertySeq> m_properties;
 };
 
@@ -8197,7 +8125,7 @@ private:
  * @brief This class represents the structure CREATE_CLIENT_Payload defined by the user in the IDL file.
  * @ingroup TYPESMOD
  */
-class CREATE_CLIENT_Payload : public BaseObjectRequest 
+class CREATE_CLIENT_Payload
 {
 public:
 
@@ -8589,7 +8517,7 @@ public:
  * @brief This class represents the structure STATUS_AGENT_Payload defined by the user in the IDL file.
  * @ingroup TYPESMOD
  */
-class STATUS_AGENT_Payload : public BaseObjectReply
+class STATUS_AGENT_Payload
 {
 public:
 

--- a/include/uxr/agent/utils/Time.hpp
+++ b/include/uxr/agent/utils/Time.hpp
@@ -1,0 +1,37 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UXR_AGENT_UTILS_TIME_HPP_
+#define UXR_AGENT_UTILS_TIME_HPP_
+
+#include <cinttypes>
+#include <chrono>
+
+namespace eprosima {
+namespace uxr {
+namespace time {
+
+inline void get_epoch_time(int32_t& sec, uint32_t& nsec)
+{
+    auto epoch_time{std::chrono::duration_cast<std::chrono::nanoseconds>
+                    (std::chrono::high_resolution_clock::now().time_since_epoch()).count()};
+    sec = int32_t(epoch_time / std::nano::den);
+    nsec = uint32_t(epoch_time % std::nano::den);
+}
+
+} // namespace eprosima
+} // namespace uxr
+} // namespace time
+
+#endif // UXR_AGENT_UTILS_TIME_HPP_

--- a/src/cpp/Root.cpp
+++ b/src/cpp/Root.cpp
@@ -135,18 +135,9 @@ dds::xrce::ResultStatus Root::create_client(
             conversion::clientkey_to_raw(client_representation.client_key()));
     }
 
-    if (dds::xrce::STATUS_OK == result_status.status())
-    {
-        auto epoch_time = std::chrono::duration_cast<std::chrono::nanoseconds>
-                          (std::chrono::high_resolution_clock::now().time_since_epoch()).count();
-        dds::xrce::Time_t timestamp;
-        timestamp.seconds(static_cast<int32_t>(epoch_time / 1000000000));
-        timestamp.nanoseconds(static_cast<uint32_t>(epoch_time % 1000000000));
-        agent_representation.agent_timestamp(timestamp);
-        agent_representation.xrce_cookie(dds::xrce::XRCE_COOKIE);
-        agent_representation.xrce_version(dds::xrce::XRCE_VERSION);
-        agent_representation.xrce_vendor_id(EPROSIMA_VENDOR_ID);
-    }
+    agent_representation.xrce_cookie(dds::xrce::XRCE_COOKIE);
+    agent_representation.xrce_version(dds::xrce::XRCE_VERSION);
+    agent_representation.xrce_vendor_id(EPROSIMA_VENDOR_ID);
 
     return result_status;
 }
@@ -156,14 +147,7 @@ dds::xrce::ResultStatus Root::get_info(dds::xrce::ObjectInfo& agent_info)
     dds::xrce::ResultStatus result_status;
 
     /* Agent config. */
-    auto epoch_time = std::chrono::duration_cast<std::chrono::nanoseconds>
-                      (std::chrono::high_resolution_clock::now().time_since_epoch()).count();
-    dds::xrce::Time_t timestamp;
-    timestamp.seconds(static_cast<int32_t>(epoch_time / 1000000000));
-    timestamp.nanoseconds(static_cast<uint32_t>(epoch_time % 1000000000));
-
     dds::xrce::AGENT_Representation agent_representation;
-    agent_representation.agent_timestamp(timestamp);
     agent_representation.xrce_cookie(dds::xrce::XRCE_COOKIE);
     agent_representation.xrce_version(dds::xrce::XRCE_VERSION);
     agent_representation.xrce_vendor_id(EPROSIMA_VENDOR_ID);

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -214,6 +214,7 @@ bool Processor::process_create_client_submessage(InputPacket& input_packet)
             }
             /* STATUS_AGENT payload. */
             dds::xrce::STATUS_AGENT_Payload status_agent;
+            status_agent.result(result);
             status_agent.agent_info(agent_representation);
 
             /* STATUS_AGENT subheader. */

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -154,6 +154,9 @@ bool Processor::process_submessage(ProxyClient& client, InputPacket& input_packe
         case dds::xrce::FRAGMENT:
             rv = process_fragment_submessage(client, input_packet);
             break;
+        case dds::xrce::TIMESTAMP:
+            rv = process_timestamp_submessage(client, input_packet);
+            break;
 //        case dds::xrce::PERFORMANCE:
 //            rv = process_performance_submessage(client, input_packet);
 //            break;

--- a/src/cpp/types/XRCETypes.cpp
+++ b/src/cpp/types/XRCETypes.cpp
@@ -8411,3 +8411,67 @@ void dds::xrce::HEARTBEAT_Payload::deserialize(eprosima::fastcdr::Cdr &dcdr)
     dcdr >> m_last_unacked_seq_nr;
     dcdr >> m_stream_id;
 }
+
+size_t dds::xrce::TIMESTAMP_Payload::getMaxCdrSerializedSize(size_t current_alignment)
+{
+    size_t initial_aligment = current_alignment;
+
+    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
+
+    return current_alignment - initial_aligment;
+}
+
+size_t dds::xrce::TIMESTAMP_Payload::getCdrSerializedSize(size_t current_alignment) const
+{
+    size_t initial_aligment = current_alignment;
+
+    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
+
+    return current_alignment - initial_aligment;
+}
+
+void dds::xrce::TIMESTAMP_Payload::serialize(eprosima::fastcdr::Cdr &scdr) const
+{
+    scdr << m_transmit_timestamp;
+}
+
+void dds::xrce::TIMESTAMP_Payload::deserialize(eprosima::fastcdr::Cdr &dcdr)
+{
+    dcdr >> m_transmit_timestamp;
+}
+
+size_t dds::xrce::TIMESTAMP_REPLY_Payload::getMaxCdrSerializedSize(size_t current_alignment)
+{
+    size_t initial_aligment = current_alignment;
+
+    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
+    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
+    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
+
+    return current_alignment - initial_aligment;
+}
+
+size_t dds::xrce::TIMESTAMP_REPLY_Payload::getCdrSerializedSize(size_t current_alignment) const
+{
+    size_t initial_aligment = current_alignment;
+
+    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
+    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
+    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
+
+    return current_alignment - initial_aligment;
+}
+
+void dds::xrce::TIMESTAMP_REPLY_Payload::serialize(eprosima::fastcdr::Cdr &scdr) const
+{
+    scdr << m_transmit_timestamp;
+    scdr << m_receive_timestamp;
+    scdr << m_originate_timestamp;
+}
+
+void dds::xrce::TIMESTAMP_REPLY_Payload::deserialize(eprosima::fastcdr::Cdr &dcdr)
+{
+    dcdr >> m_transmit_timestamp;
+    dcdr >> m_receive_timestamp;
+    dcdr >> m_originate_timestamp;
+}

--- a/src/cpp/types/XRCETypes.cpp
+++ b/src/cpp/types/XRCETypes.cpp
@@ -942,7 +942,6 @@ dds::xrce::CLIENT_Representation::CLIENT_Representation(const CLIENT_Representat
     m_xrce_cookie = x.m_xrce_cookie;
     m_xrce_version = x.m_xrce_version;
     m_xrce_vendor_id = x.m_xrce_vendor_id;
-    m_client_timestamp = x.m_client_timestamp;
     m_client_key = x.m_client_key;
     m_session_id = x.m_session_id;
     m_properties = x.m_properties;
@@ -954,7 +953,6 @@ dds::xrce::CLIENT_Representation::CLIENT_Representation(CLIENT_Representation &&
     m_xrce_cookie = std::move(x.m_xrce_cookie);
     m_xrce_version = std::move(x.m_xrce_version);
     m_xrce_vendor_id = std::move(x.m_xrce_vendor_id);
-    m_client_timestamp = std::move(x.m_client_timestamp);
     m_client_key = std::move(x.m_client_key);
     m_session_id = x.m_session_id;
     m_properties = std::move(x.m_properties);
@@ -966,7 +964,6 @@ dds::xrce::CLIENT_Representation& dds::xrce::CLIENT_Representation::operator=(co
     m_xrce_cookie = x.m_xrce_cookie;
     m_xrce_version = x.m_xrce_version;
     m_xrce_vendor_id = x.m_xrce_vendor_id;
-    m_client_timestamp = x.m_client_timestamp;
     m_client_key = x.m_client_key;
     m_session_id = x.m_session_id;
     m_properties = x.m_properties;
@@ -980,7 +977,6 @@ dds::xrce::CLIENT_Representation& dds::xrce::CLIENT_Representation::operator=(CL
     m_xrce_cookie = std::move(x.m_xrce_cookie);
     m_xrce_version = std::move(x.m_xrce_version);
     m_xrce_vendor_id = std::move(x.m_xrce_vendor_id);
-    m_client_timestamp = std::move(x.m_client_timestamp);
     m_client_key = std::move(x.m_client_key);
     m_session_id = x.m_session_id;
     m_properties = std::move(x.m_properties);
@@ -996,7 +992,6 @@ size_t dds::xrce::CLIENT_Representation::getMaxCdrSerializedSize(size_t current_
     current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += ((2) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += ((2) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
     current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
@@ -1012,7 +1007,6 @@ size_t dds::xrce::CLIENT_Representation::getCdrSerializedSize(size_t current_ali
     current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += ((2) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += ((2) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-    current_alignment += m_client_timestamp.getCdrSerializedSize(current_alignment);
     current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
 
@@ -1036,7 +1030,6 @@ void dds::xrce::CLIENT_Representation::serialize(eprosima::fastcdr::Cdr &scdr) c
     scdr << m_xrce_cookie;
     scdr << m_xrce_version;
     scdr << m_xrce_vendor_id;
-    scdr << m_client_timestamp;
     scdr << m_client_key;
     scdr << m_session_id;
     scdr << bool(m_properties);
@@ -1052,7 +1045,6 @@ void dds::xrce::CLIENT_Representation::deserialize(eprosima::fastcdr::Cdr &dcdr)
     dcdr >> m_xrce_cookie;
     dcdr >> m_xrce_version;
     dcdr >> m_xrce_vendor_id;
-    dcdr >> m_client_timestamp;
     dcdr >> m_client_key;
     dcdr >> m_session_id;
     bool m_properties_flag;
@@ -1079,7 +1071,6 @@ dds::xrce::AGENT_Representation::AGENT_Representation(const AGENT_Representation
     m_xrce_cookie = x.m_xrce_cookie;
     m_xrce_version = x.m_xrce_version;
     m_xrce_vendor_id = x.m_xrce_vendor_id;
-    m_agent_timestamp = x.m_agent_timestamp;
 }
 
 dds::xrce::AGENT_Representation::AGENT_Representation(AGENT_Representation &&x)
@@ -1087,7 +1078,6 @@ dds::xrce::AGENT_Representation::AGENT_Representation(AGENT_Representation &&x)
     m_xrce_cookie = std::move(x.m_xrce_cookie);
     m_xrce_version = std::move(x.m_xrce_version);
     m_xrce_vendor_id = std::move(x.m_xrce_vendor_id);
-    m_agent_timestamp = std::move(x.m_agent_timestamp);
 }
 
 dds::xrce::AGENT_Representation& dds::xrce::AGENT_Representation::operator=(const AGENT_Representation &x)
@@ -1095,7 +1085,6 @@ dds::xrce::AGENT_Representation& dds::xrce::AGENT_Representation::operator=(cons
     m_xrce_cookie = x.m_xrce_cookie;
     m_xrce_version = x.m_xrce_version;
     m_xrce_vendor_id = x.m_xrce_vendor_id;
-    m_agent_timestamp = x.m_agent_timestamp;
     
     return *this;
 }
@@ -1105,7 +1094,6 @@ dds::xrce::AGENT_Representation& dds::xrce::AGENT_Representation::operator=(AGEN
     m_xrce_cookie = std::move(x.m_xrce_cookie);
     m_xrce_version = std::move(x.m_xrce_version);
     m_xrce_vendor_id = std::move(x.m_xrce_vendor_id);
-    m_agent_timestamp = std::move(x.m_agent_timestamp);
     
     return *this;
 }
@@ -1117,7 +1105,6 @@ size_t dds::xrce::AGENT_Representation::getMaxCdrSerializedSize(size_t current_a
     current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += ((2) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += ((2) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-    current_alignment += dds::xrce::Time_t::getMaxCdrSerializedSize(current_alignment);
     /* TODO (Julian): add optional support for getMaxCrdSerializedSize */
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
 
@@ -1131,7 +1118,6 @@ size_t dds::xrce::AGENT_Representation::getCdrSerializedSize(size_t current_alig
     current_alignment += ((4) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += ((2) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
     current_alignment += ((2) * 1) + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
-    current_alignment += m_agent_timestamp.getCdrSerializedSize(current_alignment);
 
     /* Optional properties. */
     current_alignment += 1 + eprosima::fastcdr::Cdr::alignment(current_alignment, 1);
@@ -1151,7 +1137,6 @@ void dds::xrce::AGENT_Representation::serialize(eprosima::fastcdr::Cdr &scdr) co
     scdr << m_xrce_cookie;
     scdr << m_xrce_version;
     scdr << m_xrce_vendor_id;
-    scdr << m_agent_timestamp;
     scdr << bool(m_properties);
     if (m_properties)
     {
@@ -1164,7 +1149,6 @@ void dds::xrce::AGENT_Representation::deserialize(eprosima::fastcdr::Cdr &dcdr)
     dcdr >> m_xrce_cookie;
     dcdr >> m_xrce_version;
     dcdr >> m_xrce_vendor_id;
-    dcdr >> m_agent_timestamp;
     bool m_properties_flag;
     dcdr >> m_properties_flag;
     if (m_properties_flag)
@@ -5883,7 +5867,7 @@ void dds::xrce::DataDeliveryControl::deserialize(eprosima::fastcdr::Cdr &dcdr)
 
 dds::xrce::ReadSpecification::ReadSpecification()
 {
-    m_data_stream_id = 0;
+    m_preferred_stream_id = 0;
     m_data_format = 0;
 }
 
@@ -5893,7 +5877,7 @@ dds::xrce::ReadSpecification::~ReadSpecification()
 
 dds::xrce::ReadSpecification::ReadSpecification(const ReadSpecification &x)
 {
-    m_data_stream_id = x.m_data_stream_id;
+    m_preferred_stream_id = x.m_preferred_stream_id;
     m_data_format = x.m_data_format;
     m_content_filter_expression = x.m_content_filter_expression;
     m_delivery_control = x.m_delivery_control;
@@ -5901,7 +5885,7 @@ dds::xrce::ReadSpecification::ReadSpecification(const ReadSpecification &x)
 
 dds::xrce::ReadSpecification::ReadSpecification(ReadSpecification &&x)
 {
-    m_data_stream_id = x.m_data_stream_id;
+    m_preferred_stream_id = x.m_preferred_stream_id;
     m_data_format = x.m_data_format;
     m_content_filter_expression = std::move(x.m_content_filter_expression);
     m_delivery_control = std::move(x.m_delivery_control);
@@ -5909,7 +5893,7 @@ dds::xrce::ReadSpecification::ReadSpecification(ReadSpecification &&x)
 
 dds::xrce::ReadSpecification& dds::xrce::ReadSpecification::operator=(const ReadSpecification &x)
 {
-    m_data_stream_id = x.m_data_stream_id;
+    m_preferred_stream_id = x.m_preferred_stream_id;
     m_data_format = x.m_data_format;
     m_content_filter_expression = x.m_content_filter_expression;
     m_delivery_control = x.m_delivery_control;
@@ -5919,7 +5903,7 @@ dds::xrce::ReadSpecification& dds::xrce::ReadSpecification::operator=(const Read
 
 dds::xrce::ReadSpecification& dds::xrce::ReadSpecification::operator=(ReadSpecification &&x)
 {
-    m_data_stream_id = x.m_data_stream_id;
+    m_preferred_stream_id = x.m_preferred_stream_id;
     m_data_format = x.m_data_format;
     m_content_filter_expression = std::move(x.m_content_filter_expression);
     m_delivery_control = std::move(x.m_delivery_control);
@@ -5966,7 +5950,7 @@ size_t dds::xrce::ReadSpecification::getCdrSerializedSize(size_t current_alignme
 
 void dds::xrce::ReadSpecification::serialize(eprosima::fastcdr::Cdr &scdr) const
 {
-    scdr << m_data_stream_id;
+    scdr << m_preferred_stream_id;
     scdr << m_data_format;
     scdr << bool(m_content_filter_expression);
     if (m_content_filter_expression)
@@ -5982,7 +5966,7 @@ void dds::xrce::ReadSpecification::serialize(eprosima::fastcdr::Cdr &scdr) const
 
 void dds::xrce::ReadSpecification::deserialize(eprosima::fastcdr::Cdr &dcdr)
 {
-    dcdr >> m_data_stream_id;
+    dcdr >> m_preferred_stream_id;
     dcdr >> m_data_format;
     bool temp;
     dcdr >> temp;
@@ -7018,20 +7002,17 @@ dds::xrce::CREATE_CLIENT_Payload::~CREATE_CLIENT_Payload()
 }
 
 dds::xrce::CREATE_CLIENT_Payload::CREATE_CLIENT_Payload(const CREATE_CLIENT_Payload &x)
-    : BaseObjectRequest(x)
 {
     m_client_representation = x.m_client_representation;
 }
 
 dds::xrce::CREATE_CLIENT_Payload::CREATE_CLIENT_Payload(CREATE_CLIENT_Payload &&x)
-    : BaseObjectRequest(x)
 {
     m_client_representation = std::move(x.m_client_representation);
 }
 
 dds::xrce::CREATE_CLIENT_Payload& dds::xrce::CREATE_CLIENT_Payload::operator=(const CREATE_CLIENT_Payload &x)
 {
-    BaseObjectRequest::operator=(x);
     m_client_representation = x.m_client_representation;
     
     return *this;
@@ -7039,7 +7020,6 @@ dds::xrce::CREATE_CLIENT_Payload& dds::xrce::CREATE_CLIENT_Payload::operator=(co
 
 dds::xrce::CREATE_CLIENT_Payload& dds::xrce::CREATE_CLIENT_Payload::operator=(CREATE_CLIENT_Payload &&x)
 {
-    BaseObjectRequest::operator=(x);
     m_client_representation = std::move(x.m_client_representation);
     
     return *this;
@@ -7049,7 +7029,6 @@ size_t dds::xrce::CREATE_CLIENT_Payload::getMaxCdrSerializedSize(size_t current_
 {
     size_t initial_alignment = current_alignment;
             
-    current_alignment += dds::xrce::BaseObjectRequest::getMaxCdrSerializedSize(current_alignment);
     current_alignment += dds::xrce::CLIENT_Representation::getMaxCdrSerializedSize(current_alignment);
 
     return current_alignment - initial_alignment;
@@ -7059,7 +7038,6 @@ size_t dds::xrce::CREATE_CLIENT_Payload::getCdrSerializedSize(size_t current_ali
 {
     size_t initial_alignment = current_alignment;
             
-    current_alignment += dds::xrce::BaseObjectRequest::getCdrSerializedSize(current_alignment);
     current_alignment += m_client_representation.getCdrSerializedSize(current_alignment);
 
     return current_alignment - initial_alignment;
@@ -7067,13 +7045,11 @@ size_t dds::xrce::CREATE_CLIENT_Payload::getCdrSerializedSize(size_t current_ali
 
 void dds::xrce::CREATE_CLIENT_Payload::serialize(eprosima::fastcdr::Cdr &scdr) const
 {
-    BaseObjectRequest::serialize(scdr);
     scdr << m_client_representation;
 }
 
 void dds::xrce::CREATE_CLIENT_Payload::deserialize(eprosima::fastcdr::Cdr &dcdr)
 {
-    BaseObjectRequest::deserialize(dcdr);
     dcdr >> m_client_representation;
 }
 
@@ -7285,20 +7261,17 @@ dds::xrce::STATUS_AGENT_Payload::~STATUS_AGENT_Payload()
 }
 
 dds::xrce::STATUS_AGENT_Payload::STATUS_AGENT_Payload(const STATUS_AGENT_Payload &x)
-    : BaseObjectReply(x)
 {
     m_agent_info = x.m_agent_info;
 }
 
 dds::xrce::STATUS_AGENT_Payload::STATUS_AGENT_Payload(STATUS_AGENT_Payload &&x)
-    : BaseObjectReply(x)
 {
     m_agent_info = std::move(x.m_agent_info);
 }
 
 dds::xrce::STATUS_AGENT_Payload& dds::xrce::STATUS_AGENT_Payload::operator=(const STATUS_AGENT_Payload &x)
 {
-    BaseObjectReply::operator=(x);
     m_agent_info = x.m_agent_info;
     
     return *this;
@@ -7306,7 +7279,6 @@ dds::xrce::STATUS_AGENT_Payload& dds::xrce::STATUS_AGENT_Payload::operator=(cons
 
 dds::xrce::STATUS_AGENT_Payload& dds::xrce::STATUS_AGENT_Payload::operator=(STATUS_AGENT_Payload &&x)
 {
-    BaseObjectReply::operator=(x);
     m_agent_info = std::move(x.m_agent_info);
     
     return *this;
@@ -7316,7 +7288,6 @@ size_t dds::xrce::STATUS_AGENT_Payload::getMaxCdrSerializedSize(size_t current_a
 {
     size_t initial_alignment = current_alignment;
             
-    current_alignment += dds::xrce::BaseObjectReply::getMaxCdrSerializedSize(current_alignment);
     current_alignment += dds::xrce::AGENT_Representation::getMaxCdrSerializedSize(current_alignment);
 
     return current_alignment - initial_alignment;
@@ -7326,7 +7297,6 @@ size_t dds::xrce::STATUS_AGENT_Payload::getCdrSerializedSize(size_t current_alig
 {
     size_t initial_alignment = current_alignment;
             
-    current_alignment += dds::xrce::BaseObjectReply::getCdrSerializedSize(current_alignment);
     current_alignment += m_agent_info.getCdrSerializedSize(current_alignment);
 
     return current_alignment - initial_alignment;
@@ -7334,13 +7304,11 @@ size_t dds::xrce::STATUS_AGENT_Payload::getCdrSerializedSize(size_t current_alig
 
 void dds::xrce::STATUS_AGENT_Payload::serialize(eprosima::fastcdr::Cdr &scdr) const
 {
-    BaseObjectReply::serialize(scdr);
     scdr << m_agent_info;
 }
 
 void dds::xrce::STATUS_AGENT_Payload::deserialize(eprosima::fastcdr::Cdr &dcdr)
 {
-    BaseObjectReply::deserialize(dcdr);
     dcdr >> m_agent_info;
 }
 

--- a/src/cpp/types/XRCETypes.cpp
+++ b/src/cpp/types/XRCETypes.cpp
@@ -8380,6 +8380,14 @@ void dds::xrce::HEARTBEAT_Payload::deserialize(eprosima::fastcdr::Cdr &dcdr)
     dcdr >> m_stream_id;
 }
 
+dds::xrce::TIMESTAMP_Payload::TIMESTAMP_Payload()
+{
+}
+
+dds::xrce::TIMESTAMP_Payload::~TIMESTAMP_Payload()
+{
+}
+
 size_t dds::xrce::TIMESTAMP_Payload::getMaxCdrSerializedSize(size_t current_alignment)
 {
     size_t initial_aligment = current_alignment;
@@ -8406,6 +8414,14 @@ void dds::xrce::TIMESTAMP_Payload::serialize(eprosima::fastcdr::Cdr &scdr) const
 void dds::xrce::TIMESTAMP_Payload::deserialize(eprosima::fastcdr::Cdr &dcdr)
 {
     dcdr >> m_transmit_timestamp;
+}
+
+dds::xrce::TIMESTAMP_REPLY_Payload::TIMESTAMP_REPLY_Payload()
+{
+}
+
+dds::xrce::TIMESTAMP_REPLY_Payload::~TIMESTAMP_REPLY_Payload()
+{
 }
 
 size_t dds::xrce::TIMESTAMP_REPLY_Payload::getMaxCdrSerializedSize(size_t current_alignment)

--- a/src/cpp/types/XRCETypes.cpp
+++ b/src/cpp/types/XRCETypes.cpp
@@ -7288,6 +7288,7 @@ size_t dds::xrce::STATUS_AGENT_Payload::getMaxCdrSerializedSize(size_t current_a
 {
     size_t initial_alignment = current_alignment;
             
+    current_alignment += dds::xrce::ResultStatus::getMaxCdrSerializedSize(current_alignment);
     current_alignment += dds::xrce::AGENT_Representation::getMaxCdrSerializedSize(current_alignment);
 
     return current_alignment - initial_alignment;
@@ -7297,6 +7298,7 @@ size_t dds::xrce::STATUS_AGENT_Payload::getCdrSerializedSize(size_t current_alig
 {
     size_t initial_alignment = current_alignment;
             
+    current_alignment += m_result.getCdrSerializedSize(current_alignment);
     current_alignment += m_agent_info.getCdrSerializedSize(current_alignment);
 
     return current_alignment - initial_alignment;
@@ -7304,11 +7306,13 @@ size_t dds::xrce::STATUS_AGENT_Payload::getCdrSerializedSize(size_t current_alig
 
 void dds::xrce::STATUS_AGENT_Payload::serialize(eprosima::fastcdr::Cdr &scdr) const
 {
+    scdr << m_result;
     scdr << m_agent_info;
 }
 
 void dds::xrce::STATUS_AGENT_Payload::deserialize(eprosima::fastcdr::Cdr &dcdr)
 {
+    dcdr >> m_result;
     dcdr >> m_agent_info;
 }
 

--- a/test/blackbox/tree/TreeTests.cpp
+++ b/test/blackbox/tree/TreeTests.cpp
@@ -46,8 +46,6 @@ TEST_F(TreeTests, XMLTree)
     client_representation.xrce_cookie(dds::xrce::XRCE_COOKIE);
     client_representation.xrce_version(dds::xrce::XRCE_VERSION);
     client_representation.xrce_vendor_id(vendor_id_);
-    client_representation.client_timestamp().seconds(0x00);
-    client_representation.client_timestamp().nanoseconds(0x00);
     client_representation.client_key(client_key_);
     client_representation.session_id(0x00);
     dds::xrce::ResultStatus response = root_.create_client(
@@ -180,8 +178,6 @@ TEST_F(TreeTests, REFTree)
     client_representation.xrce_cookie(dds::xrce::XRCE_COOKIE);
     client_representation.xrce_version(dds::xrce::XRCE_VERSION);
     client_representation.xrce_vendor_id(vendor_id_);
-    client_representation.client_timestamp().seconds(0x00);
-    client_representation.client_timestamp().nanoseconds(0x00);
     client_representation.client_key(client_key_);
     client_representation.session_id(0x00);
     dds::xrce::ResultStatus response = root_.create_client(
@@ -403,8 +399,6 @@ TEST_F(TreeTests, CreationModeXMLTree)
     client_representation.xrce_cookie(dds::xrce::XRCE_COOKIE);
     client_representation.xrce_version(dds::xrce::XRCE_VERSION);
     client_representation.xrce_vendor_id(vendor_id_);
-    client_representation.client_timestamp().seconds(0x00);
-    client_representation.client_timestamp().nanoseconds(0x00);
     client_representation.client_key(client_key_);
     client_representation.session_id(0x00);
     dds::xrce::ResultStatus response = root_.create_client(
@@ -681,8 +675,6 @@ TEST_F(TreeTests, CreationModeREFTree)
     client_representation.xrce_cookie(dds::xrce::XRCE_COOKIE);
     client_representation.xrce_version(dds::xrce::XRCE_VERSION);
     client_representation.xrce_vendor_id(vendor_id_);
-    client_representation.client_timestamp().seconds(0x00);
-    client_representation.client_timestamp().nanoseconds(0x00);
     client_representation.client_key(client_key_);
     client_representation.session_id(0x00);
     dds::xrce::ResultStatus response = root_.create_client(

--- a/test/integration/cross_serialization/AgentSerialization.cpp
+++ b/test/integration/cross_serialization/AgentSerialization.cpp
@@ -25,13 +25,9 @@ std::vector<uint8_t> AgentSerialization::create_client_payload()
 
     /* Payload. */
     dds::xrce::CREATE_CLIENT_Payload payload;
-    payload.request_id() = {0x01, 0x23};
-    payload.object_id() = {0x45, 0x67};
     payload.client_representation().xrce_cookie() = {0x89, 0xAB, 0xCD, 0xEF};
     payload.client_representation().xrce_version() = {0x01, 0x23};
     payload.client_representation().xrce_vendor_id() = {0x45, 0x67};
-    payload.client_representation().client_timestamp().seconds() = 0x89ABCDEF;
-    payload.client_representation().client_timestamp().nanoseconds() = 0x01234567;
     payload.client_representation().client_key() = {0x89, 0xAB, 0xCD, 0xEF};
     payload.client_representation().session_id() = 0x01;
     payload.client_representation().mtu() = 0x2345;
@@ -158,15 +154,9 @@ std::vector<uint8_t> AgentSerialization::status_agent_payload()
 
     /* Payload. */
     dds::xrce::STATUS_AGENT_Payload payload;
-    payload.related_request().request_id() = {0x01, 0x23};
-    payload.related_request().object_id() = {0x45, 0x67};
     payload.agent_info().xrce_cookie({0x89, 0xAB, 0xCD, 0xEF});
     payload.agent_info().xrce_version({0x01, 0x23});
     payload.agent_info().xrce_vendor_id({0x45, 0x67});
-    dds::xrce::Time_t time;
-    time.seconds(0x89ABCDEF);
-    time.nanoseconds(0x01234567);
-    payload.agent_info().agent_timestamp(time);
 
     /* Subheader. */
     dds::xrce::SubmessageHeader subheader;
@@ -244,10 +234,6 @@ std::vector<uint8_t> AgentSerialization::info_payload()
     agent_config.xrce_cookie({0x89, 0xAB, 0xCD, 0xEF});
     agent_config.xrce_version({0x01, 0x23});
     agent_config.xrce_vendor_id({0x45, 0x67});
-    dds::xrce::Time_t time;
-    time.seconds(0x89ABCDEF);
-    time.nanoseconds(0x01234567);
-    agent_config.agent_timestamp(time);
 
     dds::xrce::ObjectVariant config;
     config.agent(agent_config);
@@ -289,7 +275,6 @@ std::vector<uint8_t> AgentSerialization::read_data_payload()
     dds::xrce::READ_DATA_Payload payload;
     payload.request_id() = {0x01, 0x23};
     payload.object_id() = {0x45, 0x67};
-    payload.read_specification().data_stream_id() = 0x80;
     payload.read_specification().data_format() = 0x89;
 
     dds::xrce::DataDeliveryControl delivery_control;

--- a/test/integration/cross_serialization/AgentSerialization.cpp
+++ b/test/integration/cross_serialization/AgentSerialization.cpp
@@ -154,6 +154,8 @@ std::vector<uint8_t> AgentSerialization::status_agent_payload()
 
     /* Payload. */
     dds::xrce::STATUS_AGENT_Payload payload;
+    payload.result().status() = dds::xrce::StatusValue(0x01);
+    payload.result().implementation_status() = {0x23};
     payload.agent_info().xrce_cookie({0x89, 0xAB, 0xCD, 0xEF});
     payload.agent_info().xrce_version({0x01, 0x23});
     payload.agent_info().xrce_vendor_id({0x45, 0x67});
@@ -188,7 +190,7 @@ std::vector<uint8_t> AgentSerialization::status_payload()
     payload.related_request().request_id() = {0x01, 0x23};
     payload.related_request().object_id() = {0x45, 0x67};
     payload.result().implementation_status() = 0x89;
-    payload.result().status() = (dds::xrce::StatusValue)0xAB;
+    payload.result().status() = dds::xrce::StatusValue(0xAB);
 
     /* Subheader. */
     dds::xrce::SubmessageHeader subheader;
@@ -242,7 +244,7 @@ std::vector<uint8_t> AgentSerialization::info_payload()
     payload.related_request().request_id() = {0x01, 0x23};
     payload.related_request().object_id() = {0x45, 0x67};
     payload.result().implementation_status() = 0x89;
-    payload.result().status() = (dds::xrce::StatusValue)0xAB;
+    payload.result().status() = dds::xrce::StatusValue(0xAB);
     payload.object_info().activity(activity);
     payload.object_info().config(config);
 
@@ -275,6 +277,7 @@ std::vector<uint8_t> AgentSerialization::read_data_payload()
     dds::xrce::READ_DATA_Payload payload;
     payload.request_id() = {0x01, 0x23};
     payload.object_id() = {0x45, 0x67};
+    payload.read_specification().preferred_stream_id() = 0x80;
     payload.read_specification().data_format() = 0x89;
 
     dds::xrce::DataDeliveryControl delivery_control;

--- a/test/unittest/Common.cpp
+++ b/test/unittest/Common.cpp
@@ -41,8 +41,6 @@ dds::xrce::SubmessageHeader CommonData::generate_submessage_header(const dds::xr
 dds::xrce::CREATE_CLIENT_Payload CommonData::generate_create_client_payload() const
 {
     dds::xrce::CREATE_CLIENT_Payload create_data;
-    create_data.request_id(request_id);
-    create_data.object_id(object_id);
     create_data.client_representation(generate_client_representation());
     return create_data;
 }
@@ -70,7 +68,6 @@ dds::xrce::CLIENT_Representation CommonData::generate_client_representation() co
     client_representation.xrce_cookie(dds::xrce::XRCE_COOKIE);
     client_representation.xrce_version(dds::xrce::XRCE_VERSION);
     client_representation.xrce_vendor_id(vendor_id);
-    client_representation.client_timestamp();
     client_representation.client_key(client_key);
     client_representation.session_id();
     client_representation.properties();


### PR DESCRIPTION
This pull request contains the following changes:

-   XRCE types have been modified according to the new version of the standard (ptc/19-03-27).
-   A time synchronization mechanism has been added using the new submessages TIEMSTAMP and TIMESTAMP_REPLY.
