### PR TITLE
Linux server will now wait for SIGTERM instead of 'q'.

### DIFF
--- a/include/uxr/agent/utils/CLI.hpp
+++ b/include/uxr/agent/utils/CLI.hpp
@@ -26,6 +26,8 @@
 
 #include <termios.h>
 #include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
 #endif //_WIN32
 
 #include <uxr/agent/Agent.hpp>
@@ -264,7 +266,11 @@ public:
 private:
     void server_callback()
     {
+#ifdef _WIN32
         std::cout << "Enter 'q' for exit" << std::endl;
+#else
+        std::cout << "Press CTRL+C to exit" << std::endl;
+#endif
         if (launch_server())
         {
 #ifdef UAGENT_DISCOVERY_PROFILE


### PR DESCRIPTION
This will prevent an infinite loop from occurring if the agent is started as a Linux daemon, if stdin is redirected to /dev/null.

Related to #100.