### PR TITLE
Fixed various TCP-related deadlocks and improved disconnection mechanism

### DIFF
--- a/src/cpp/transport/tcp/TCPServerLinux.cpp
+++ b/src/cpp/transport/tcp/TCPServerLinux.cpp
@@ -391,6 +391,16 @@ bool TCPv4Agent::close_connection(TCPConnection& connection)
         lock.unlock();
         /* Add lock for close. */
         std::unique_lock<std::mutex> conn_lock(connection.mtx);
+
+        /* Synchronize the stream with the client, to avoid losing bytes currently in flight. */
+        shutdown(connection_platform.poll_fd->fd, SHUT_WR);
+        int poll_rv = poll(connection_platform.poll_fd, 1, 10000);
+        if (0 < poll_rv)
+        {
+            char dummy;
+            while (recv(connection_platform.poll_fd->fd, &dummy, sizeof(dummy), 0) > 0) {};
+        }
+
         if (0 == ::close(connection_platform.poll_fd->fd))
         {
             connection_platform.poll_fd->fd = -1;

--- a/src/cpp/transport/tcp/TCPServerLinux.cpp
+++ b/src/cpp/transport/tcp/TCPServerLinux.cpp
@@ -78,71 +78,83 @@ bool TCPv4Agent::init()
 
     if (-1 != listener_poll_.fd)
     {
-        /* IP and Port setup. */
-        struct sockaddr_in address;
-        address.sin_family = AF_INET;
-        address.sin_port = htons(transport_address_.medium_locator().port());
-        address.sin_addr.s_addr = INADDR_ANY;
-        memset(address.sin_zero, '\0', sizeof(address.sin_zero));
-        if (-1 != bind(listener_poll_.fd, (struct sockaddr*)&address, sizeof(address)))
+        /* Set reuse port. */
+        int reuse = 1;
+        if (-1 != setsockopt(listener_poll_.fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)))
         {
-            /* Log. */
-            UXR_AGENT_LOG_DEBUG(
-                UXR_DECORATE_GREEN("port opened"),
-                "port: {}",
-                transport_address_.medium_locator().port());
-
-            /* Setup listener poll. */
-            listener_poll_.events = POLLIN;
-
-            /* Setup connections. */
-            for (size_t i = 0; i < poll_fds_.size(); ++i)
+            /* IP and Port setup. */
+            struct sockaddr_in address;
+            address.sin_family = AF_INET;
+            address.sin_port = htons(transport_address_.medium_locator().port());
+            address.sin_addr.s_addr = INADDR_ANY;
+            memset(address.sin_zero, '\0', sizeof(address.sin_zero));
+            if (-1 != bind(listener_poll_.fd, (struct sockaddr*)&address, sizeof(address)))
             {
-                poll_fds_[i].fd = -1;
-                poll_fds_[i].events = POLLIN;
-                connections_[i].poll_fd = &poll_fds_[i];
-                connections_[i].id = uint32_t(i);
-                connections_[i].active = false;
-                init_input_buffer(connections_[i].input_buffer);
-                free_connections_.push_back(connections_[i].id);
-            }
+                /* Log. */
+                UXR_AGENT_LOG_DEBUG(
+                    UXR_DECORATE_GREEN("port opened"),
+                    "port: {}",
+                    transport_address_.medium_locator().port());
 
-            /* Init listener. */
-            if (-1 != listen(listener_poll_.fd, TCP_MAX_BACKLOG_CONNECTIONS))
-            {
-                running_cond_ = true;
-                listener_thread_ = std::thread(&TCPv4Agent::listener_loop, this);
+                /* Setup listener poll. */
+                listener_poll_.events = POLLIN;
 
-                /* Get local address. */
-                int fd = socket(PF_INET, SOCK_DGRAM, 0);
-                struct sockaddr_in temp_addr;
-                temp_addr.sin_family = AF_INET;
-                temp_addr.sin_port = htons(80);
-                temp_addr.sin_addr.s_addr = inet_addr("1.2.3.4");
-                int connected = connect(fd, (struct sockaddr *)&temp_addr, sizeof(temp_addr));
-                if (0 == connected)
+                /* Setup connections. */
+                for (size_t i = 0; i < poll_fds_.size(); ++i)
                 {
-                    struct sockaddr local_addr;
-                    socklen_t local_addr_len = sizeof(local_addr);
-                    if (-1 != getsockname(fd, &local_addr, &local_addr_len))
+                    poll_fds_[i].fd = -1;
+                    poll_fds_[i].events = POLLIN;
+                    connections_[i].poll_fd = &poll_fds_[i];
+                    connections_[i].id = uint32_t(i);
+                    connections_[i].active = false;
+                    init_input_buffer(connections_[i].input_buffer);
+                    free_connections_.push_back(connections_[i].id);
+                }
+
+                /* Init listener. */
+                if (-1 != listen(listener_poll_.fd, TCP_MAX_BACKLOG_CONNECTIONS))
+                {
+                    running_cond_ = true;
+                    listener_thread_ = std::thread(&TCPv4Agent::listener_loop, this);
+
+                    /* Get local address. */
+                    int fd = socket(PF_INET, SOCK_DGRAM, 0);
+                    struct sockaddr_in temp_addr;
+                    temp_addr.sin_family = AF_INET;
+                    temp_addr.sin_port = htons(80);
+                    temp_addr.sin_addr.s_addr = inet_addr("1.2.3.4");
+                    int connected = connect(fd, (struct sockaddr *)&temp_addr, sizeof(temp_addr));
+                    if (0 == connected)
                     {
-                        transport_address_.medium_locator().address({uint8_t(local_addr.sa_data[2]),
-                                                                     uint8_t(local_addr.sa_data[3]),
-                                                                     uint8_t(local_addr.sa_data[4]),
-                                                                     uint8_t(local_addr.sa_data[5])});
-                        rv = true;
-                        UXR_AGENT_LOG_INFO(
-                            UXR_DECORATE_GREEN("running..."),
-                            "port: {}",
-                            transport_address_.medium_locator().port());
+                        struct sockaddr local_addr;
+                        socklen_t local_addr_len = sizeof(local_addr);
+                        if (-1 != getsockname(fd, &local_addr, &local_addr_len))
+                        {
+                            transport_address_.medium_locator().address({uint8_t(local_addr.sa_data[2]),
+                                                                         uint8_t(local_addr.sa_data[3]),
+                                                                         uint8_t(local_addr.sa_data[4]),
+                                                                         uint8_t(local_addr.sa_data[5])});
+                            rv = true;
+                            UXR_AGENT_LOG_INFO(
+                                UXR_DECORATE_GREEN("running..."),
+                                "port: {}",
+                                transport_address_.medium_locator().port());
+                        }
+                        ::close(fd);
                     }
-                    ::close(fd);
+                }
+                else
+                {
+                    UXR_AGENT_LOG_ERROR(
+                        UXR_DECORATE_RED("listen error"),
+                        "port: {}",
+                        transport_address_.medium_locator().port());
                 }
             }
             else
             {
                 UXR_AGENT_LOG_ERROR(
-                    UXR_DECORATE_RED("listen error"),
+                    UXR_DECORATE_RED("bind error"),
                     "port: {}",
                     transport_address_.medium_locator().port());
             }
@@ -150,9 +162,9 @@ bool TCPv4Agent::init()
         else
         {
             UXR_AGENT_LOG_ERROR(
-                UXR_DECORATE_RED("bind error"),
-                "port: {}",
-                transport_address_.medium_locator().port());
+                UXR_DECORATE_RED("socket opt error"),
+                "Port: {}",
+                listener_poll_.fd);
         }
     }
     else

--- a/src/cpp/transport/tcp/TCPServerLinux.cpp
+++ b/src/cpp/transport/tcp/TCPServerLinux.cpp
@@ -445,6 +445,11 @@ bool TCPv4Agent::read_message(int timeout)
                     rv = true;
                 }
             }
+            else if (0 < ((POLLERR | POLLHUP) & conn.poll_fd->revents))
+            {
+                /* Disconnect failed connections. */
+                close_connection(conn);
+            }
         }
     }
     else
@@ -519,6 +524,10 @@ size_t TCPv4Agent::recv_locking(
             errcode = (0 == poll_rv) ? 0 : 1;
         }
     }
+    else
+    {
+        errcode = 1;
+    }
     return rv;
 }
 
@@ -543,6 +552,10 @@ size_t TCPv4Agent::send_locking(
         {
             errcode = 1;
         }
+    }
+    else
+    {
+        errcode = 1;
     }
     return rv;
 }

--- a/src/cpp/transport/tcp/TCPServerWindows.cpp
+++ b/src/cpp/transport/tcp/TCPServerWindows.cpp
@@ -416,6 +416,11 @@ bool TCPv4Agent::read_message(int timeout)
                     rv = true;
                 }
             }
+            else if (0 < ((POLLERR | POLLHUP) & conn.poll_fd->revents))
+            {
+                /* Disconnect failed connections. */
+                close_connection(conn);
+            }
         }
     }
     else
@@ -490,6 +495,10 @@ size_t TCPv4Agent::recv_locking(
             errcode = (0 == poll_rv) ? 0 : 1;
         }
     }
+    else
+    {
+        errcode = 1;
+    }
     return rv;
 }
 
@@ -514,6 +523,10 @@ size_t TCPv4Agent::send_locking(
         {
             errcode = 1;
         }
+    }
+    else
+    {
+        errcode = 1;
     }
     return rv;
 }


### PR DESCRIPTION
1. TCPServer::listener_loop() not disconnecting failed/disconnected sockets, leaving the socket unusable.
2. Fixed TCPServer::recv_locking() and TCPServer::send_locking() not indicating the non-active connection state as an error, which previously resulted in the caller entering an infinite loop.
3. Synchronize the TCP stream with the client before closing the socket, to avoid possibly losing bytes in flight.

(3) revolves around the fact that send() does not guarantee that the receiver will receive all data. By waiting for the other side (the agent in this case) to also close the connection, we can be sure that all data that should have been received, was received. This also solves another problem: under such a condition, calling close() on the socket() will result in the remote end sending a TCP RST in response to the FIN-ACK.