### PR TITLE
DataReader closing

### DIFF
--- a/include/uxr/agent/client/ProxyClient.hpp
+++ b/include/uxr/agent/client/ProxyClient.hpp
@@ -24,7 +24,7 @@
 namespace eprosima {
 namespace uxr {
 
-class ProxyClient
+class ProxyClient : public std::enable_shared_from_this<ProxyClient>
 {
 public:
     enum class State : uint8_t
@@ -64,11 +64,15 @@ public:
 
     dds::xrce::SessionId get_session_id() const { return representation_.session_id(); }
 
+    void release();
+
     Session& session();
 
     State get_state();
 
     void update_state();
+
+    Middleware& get_middleware() { return *middleware_ ; };
 
 private:
     bool create_object(

--- a/include/uxr/agent/datareader/DataReader.hpp
+++ b/include/uxr/agent/datareader/DataReader.hpp
@@ -26,15 +26,16 @@
 namespace eprosima {
 namespace uxr {
 
+class ProxyClient;
 class Subscriber;
 class Topic;
-class Middleware;
 
 /**
  * Callback data structure.
  */
 struct ReadCallbackArgs
 {
+    std::shared_ptr<ProxyClient> client;
     dds::xrce::ClientKey client_key;
     dds::xrce::StreamId stream_id;
     dds::xrce::ObjectId object_id;
@@ -67,8 +68,6 @@ public:
 
     bool matched(
             const dds::xrce::ObjectVariant& new_object_rep) const override;
-
-    Middleware& get_middleware() const override;
 
     bool read(
         const dds::xrce::READ_DATA_Payload& read_data,

--- a/include/uxr/agent/datawriter/DataWriter.hpp
+++ b/include/uxr/agent/datawriter/DataWriter.hpp
@@ -43,7 +43,6 @@ public:
 
     void release(ObjectContainer&) override {}
     bool matched(const dds::xrce::ObjectVariant& new_object_rep) const override;
-    Middleware& get_middleware() const override;
 
     bool write(dds::xrce::WRITE_DATA_Payload_Data& write_data);
     bool write(const std::vector<uint8_t>& data);

--- a/include/uxr/agent/object/XRCEObject.hpp
+++ b/include/uxr/agent/object/XRCEObject.hpp
@@ -56,7 +56,6 @@ public:
     uint16_t get_raw_id() const { return conversion::objectid_to_raw(id_); }
     virtual bool matched(const dds::xrce::ObjectVariant& new_object_rep) const = 0;
     virtual void release(ObjectContainer& root_objects) = 0;
-    virtual Middleware& get_middleware() const = 0;
 
 private:
     dds::xrce::ObjectId id_;

--- a/include/uxr/agent/participant/Participant.hpp
+++ b/include/uxr/agent/participant/Participant.hpp
@@ -23,14 +23,15 @@
 namespace eprosima {
 namespace uxr {
 
-class Middleware;
+class ProxyClient;
 
 class Participant : public XRCEObject
 {
 public:
-    static std::unique_ptr<Participant> create(const dds::xrce::ObjectId& object_id,
-        const dds::xrce::OBJK_PARTICIPANT_Representation& representation,
-        Middleware& middleware);
+    static std::unique_ptr<Participant> create(
+        const dds::xrce::ObjectId& object_id,
+        const std::shared_ptr<ProxyClient>& proxy_client,
+        const dds::xrce::OBJK_PARTICIPANT_Representation& representation);
 
     virtual ~Participant() override;
 
@@ -43,16 +44,17 @@ public:
     void tie_object(const dds::xrce::ObjectId& object_id) { tied_objects_.insert(object_id); }
     void untie_object(const dds::xrce::ObjectId& object_id) { tied_objects_.erase(object_id); }
     bool matched(const dds::xrce::ObjectVariant& new_object_rep) const override;
-    Middleware& get_middleware() const override { return middleware_; }
+
+    const std::shared_ptr<ProxyClient>& get_proxy_client() { return proxy_client_; };
 
 private:
     Participant(
         const dds::xrce::ObjectId& id,
-        Middleware& middleware);
+        const std::shared_ptr<ProxyClient>& proxy_client);
 
 private:
+    std::shared_ptr<ProxyClient> proxy_client_;
     std::set<dds::xrce::ObjectId> tied_objects_;
-    Middleware& middleware_;
 };
 
 } // namespace uxr

--- a/include/uxr/agent/publisher/Publisher.hpp
+++ b/include/uxr/agent/publisher/Publisher.hpp
@@ -43,7 +43,6 @@ public:
     void tie_object(const dds::xrce::ObjectId& object_id) { tied_objects_.insert(object_id); }
     void untie_object(const dds::xrce::ObjectId& object_id) { tied_objects_.erase(object_id); }
     bool matched(const dds::xrce::ObjectVariant& ) const override { return true; }
-    Middleware& get_middleware() const override;
 
     const std::shared_ptr<Participant>& get_participant() { return participant_; }
 

--- a/include/uxr/agent/subscriber/Subscriber.hpp
+++ b/include/uxr/agent/subscriber/Subscriber.hpp
@@ -42,7 +42,6 @@ public:
     void tie_object(const dds::xrce::ObjectId& object_id) { tied_objects_.insert(object_id); }
     void untie_object(const dds::xrce::ObjectId& object_id) { tied_objects_.erase(object_id); }
     bool matched(const dds::xrce::ObjectVariant& ) const override { return true; }
-    Middleware& get_middleware() const override;
 
     const std::shared_ptr<Participant>& get_participant() { return participant_; }
 

--- a/include/uxr/agent/topic/Topic.hpp
+++ b/include/uxr/agent/topic/Topic.hpp
@@ -44,7 +44,6 @@ public:
     void tie_object(const dds::xrce::ObjectId& object_id) { tied_objects_.insert(object_id); }
     void untie_object(const dds::xrce::ObjectId& object_id) { tied_objects_.erase(object_id); }
     bool matched(const dds::xrce::ObjectVariant& new_object_rep) const override;
-    Middleware& get_middleware() const override;
 
 private:
     Topic(

--- a/src/cpp/Root.cpp
+++ b/src/cpp/Root.cpp
@@ -291,6 +291,11 @@ void Root::set_verbose_level(uint8_t verbose_level)
 void Root::reset()
 {
     std::lock_guard<std::mutex> lock(mtx_);
+    for (auto it = clients_.begin(); it != clients_.end(); )
+    {
+        it->second->release();
+        it = clients_.erase(it);
+    }
     clients_.clear();
     current_client_ = clients_.begin();
 }

--- a/src/cpp/Root.cpp
+++ b/src/cpp/Root.cpp
@@ -43,7 +43,14 @@ Root::Root()
 }
 
 /* It must be here instead of the hpp because the forward declaration of Middleware in the hpp. */
-Root::~Root() = default;
+Root::~Root()
+{
+    for (auto it = clients_.begin(); it != clients_.end(); )
+    {
+        it->second->release();
+        it = clients_.erase(it);
+    }
+}
 
 dds::xrce::ResultStatus Root::create_client(
         const dds::xrce::CLIENT_Representation& client_representation,
@@ -157,13 +164,14 @@ dds::xrce::ResultStatus Root::get_info(dds::xrce::ObjectInfo& agent_info)
 dds::xrce::ResultStatus Root::delete_client(const dds::xrce::ClientKey& client_key)
 {
     dds::xrce::ResultStatus result_status;
-    if (get_client(client_key))
+    if (std::shared_ptr<ProxyClient> client = get_client(client_key))
     {
         std::lock_guard<std::mutex> lock(mtx_);
         if (current_client_ != clients_.end() && client_key == current_client_->first)
         {
             ++current_client_;
         }
+        client->release();
         clients_.erase(client_key);
         result_status.status(dds::xrce::STATUS_OK);
         UXR_AGENT_LOG_INFO(

--- a/src/cpp/client/ProxyClient.cpp
+++ b/src/cpp/client/ProxyClient.cpp
@@ -195,6 +195,11 @@ std::shared_ptr<XRCEObject> ProxyClient::get_object(const dds::xrce::ObjectId& o
     return object;
 }
 
+void ProxyClient::release()
+{
+    objects_.clear();
+}
+
 Session& ProxyClient::session()
 {
     return session_;
@@ -248,7 +253,7 @@ bool ProxyClient::create_participant(
 {
     bool rv = false;
 
-    if (std::unique_ptr<Participant> participant = Participant::create(object_id, representation, *middleware_))
+    if (std::unique_ptr<Participant> participant = Participant::create(object_id, shared_from_this(), representation))
     {
         if (objects_.emplace(object_id, std::move(participant)).second)
         {

--- a/src/cpp/processor/Processor.cpp
+++ b/src/cpp/processor/Processor.cpp
@@ -654,7 +654,6 @@ bool Processor::read_data_callback(
         std::chrono::milliseconds timeout)
 {
     bool rv = false;
-    std::shared_ptr<ProxyClient> client = root_.get_client(cb_args.client_key);
 
     /* DATA payload. */
     dds::xrce::DATA_Payload_Data data_payload;
@@ -668,10 +667,10 @@ bool Processor::read_data_callback(
     if (output_packet.destination)
     {
         /* Push submessage into the output stream. */
-        rv = client->session().push_output_submessage(cb_args.stream_id, dds::xrce::DATA, data_payload, timeout);
+        rv = cb_args.client->session().push_output_submessage(cb_args.stream_id, dds::xrce::DATA, data_payload, timeout);
 
         /* Set output message. */
-        while (client->session().get_next_output_message(cb_args.stream_id, output_packet.message))
+        while (cb_args.client->session().get_next_output_message(cb_args.stream_id, output_packet.message))
         {
             /* Send message. */
             server_.push_output_packet(output_packet);

--- a/src/cpp/publisher/Publisher.cpp
+++ b/src/cpp/publisher/Publisher.cpp
@@ -14,7 +14,7 @@
 
 #include <uxr/agent/publisher/Publisher.hpp>
 #include <uxr/agent/participant/Participant.hpp>
-#include <uxr/agent/middleware/Middleware.hpp>
+#include <uxr/agent/client/ProxyClient.hpp>
 
 namespace eprosima {
 namespace uxr {
@@ -27,7 +27,7 @@ std::unique_ptr<Publisher> Publisher::create(
     bool created_entity = false;
     uint16_t raw_object_id = conversion::objectid_to_raw(object_id);
 
-    Middleware& middleware = participant->get_middleware();
+    Middleware& middleware = participant->get_proxy_client()->get_middleware();
     switch (representation.representation()._d())
     {
         case dds::xrce::REPRESENTATION_AS_XML_STRING:
@@ -58,7 +58,7 @@ Publisher::Publisher(
 Publisher::~Publisher()
 {
     participant_->untie_object(get_id());
-    get_middleware().delete_publisher(get_raw_id());
+    participant_->get_proxy_client()->get_middleware().delete_publisher(get_raw_id());
 }
 
 void Publisher::release(ObjectContainer& root_objects)
@@ -69,11 +69,6 @@ void Publisher::release(ObjectContainer& root_objects)
         root_objects.at(*obj)->release(root_objects);
         root_objects.erase(*obj);
     }
-}
-
-Middleware& Publisher::get_middleware() const
-{
-    return participant_->get_middleware();
 }
 
 } // namespace uxr

--- a/src/cpp/subscriber/Subscriber.cpp
+++ b/src/cpp/subscriber/Subscriber.cpp
@@ -14,7 +14,7 @@
 
 #include <uxr/agent/subscriber/Subscriber.hpp>
 #include <uxr/agent/participant/Participant.hpp>
-#include <uxr/agent/middleware/Middleware.hpp>
+#include <uxr/agent/client/ProxyClient.hpp>
 
 namespace eprosima {
 namespace uxr {
@@ -27,7 +27,7 @@ std::unique_ptr<Subscriber> Subscriber::create(
     bool created_entity = false;
     uint16_t raw_object_id = conversion::objectid_to_raw(object_id);
 
-    Middleware& middleware = participant->get_middleware();
+    Middleware& middleware = participant->get_proxy_client()->get_middleware();
     switch (representation.representation()._d())
     {
         case dds::xrce::REPRESENTATION_AS_XML_STRING:
@@ -58,7 +58,7 @@ Subscriber::Subscriber(
 Subscriber::~Subscriber()
 {
     participant_->untie_object(get_id());
-    get_middleware().delete_subscriber(get_raw_id());
+    participant_->get_proxy_client()->get_middleware().delete_subscriber(get_raw_id());
 }
 
 void Subscriber::release(ObjectContainer& root_objects)
@@ -69,11 +69,6 @@ void Subscriber::release(ObjectContainer& root_objects)
         root_objects.at(*obj)->release(root_objects);
         root_objects.erase(*obj);
     }
-}
-
-Middleware& Subscriber::get_middleware() const
-{
-    return participant_->get_middleware();
 }
 
 } // namespace uxr

--- a/src/cpp/topic/Topic.cpp
+++ b/src/cpp/topic/Topic.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include <uxr/agent/topic/Topic.hpp>
-#include <uxr/agent/middleware/Middleware.hpp>
 #include <uxr/agent/participant/Participant.hpp>
+#include <uxr/agent/client/ProxyClient.hpp>
 
 namespace eprosima {
 namespace uxr {
@@ -27,7 +27,7 @@ std::unique_ptr<Topic> Topic::create(
     bool created_entity = false;
     uint16_t raw_object_id = conversion::objectid_to_raw(object_id);
 
-    Middleware& middleware = participant->get_middleware();
+    Middleware& middleware = participant->get_proxy_client()->get_middleware();
     switch (representation.representation()._d())
     {
         case dds::xrce::REPRESENTATION_BY_REFERENCE:
@@ -61,7 +61,7 @@ Topic::Topic(
 Topic::~Topic()
 {
     participant_->untie_object(get_id());
-    get_middleware().delete_topic(get_raw_id());
+    participant_->get_proxy_client()->get_middleware().delete_topic(get_raw_id());
 }
 
 void Topic::release(ObjectContainer& root_objects)
@@ -88,24 +88,19 @@ bool Topic::matched(const dds::xrce::ObjectVariant& new_object_rep) const
         case dds::xrce::REPRESENTATION_BY_REFERENCE:
         {
             const std::string& ref = new_object_rep.topic().representation().object_reference();
-            rv = get_middleware().matched_topic_from_ref(get_raw_id(), ref);
+            rv = participant_->get_proxy_client()->get_middleware().matched_topic_from_ref(get_raw_id(), ref);
             break;
         }
         case dds::xrce::REPRESENTATION_AS_XML_STRING:
         {
             const std::string& xml = new_object_rep.topic().representation().xml_string_representation();
-            rv = get_middleware().matched_topic_from_xml(get_raw_id(), xml);
+            rv = participant_->get_proxy_client()->get_middleware().matched_topic_from_xml(get_raw_id(), xml);
             break;
         }
         default:
             break;
     }
     return rv;
-}
-
-Middleware& Topic::get_middleware() const
-{
-    return participant_->get_middleware();
 }
 
 } // namespace uxr

--- a/test/mock/ProxyClient/uxr/agent/client/ProxyClient.hpp
+++ b/test/mock/ProxyClient/uxr/agent/client/ProxyClient.hpp
@@ -42,6 +42,8 @@ public:
 
     MOCK_METHOD0(get_session_id, dds::xrce::SessionId());
     MOCK_METHOD0(session, Session&());
+
+    void release() {}
 };
 
 } // namespace uxr


### PR DESCRIPTION
This pull request fixes the `DataReader` closing.
Previously, when a `ProxyClient` was destroyed with a running `read_task`, an interlock took place.