### PR TITLE
DiscoveryServer modification [7903]

### DIFF
--- a/include/uxr/agent/transport/discovery/DiscoveryServerLinux.hpp
+++ b/include/uxr/agent/transport/discovery/DiscoveryServerLinux.hpp
@@ -48,8 +48,6 @@ private:
     bool send_message(
             OutputPacket<IPv4EndPoint>&& output_packet) final;
 
-    bool update_interfaces();
-
 private:
     struct pollfd poll_fd_;
     uint8_t buffer_[128];

--- a/include/uxr/agent/transport/discovery/DiscoveryServerWindows.hpp
+++ b/include/uxr/agent/transport/discovery/DiscoveryServerWindows.hpp
@@ -48,8 +48,6 @@ private:
     bool send_message(
             OutputPacket<IPv4EndPoint>&& output_packet) final;
 
-    bool update_interfaces();
-
 private:
     struct pollfd poll_fd_;
     uint8_t buffer_[128];

--- a/include/uxr/agent/transport/util/InterfaceLinux.hpp
+++ b/include/uxr/agent/transport/util/InterfaceLinux.hpp
@@ -35,6 +35,7 @@ void get_transport_interfaces(
     std::vector<dds::xrce::TransportAddress>& transport_addresses);
 
 template<>
+inline
 void get_transport_interfaces<IPv4EndPoint>(
     uint16_t agent_port,
     std::vector<dds::xrce::TransportAddress>& transport_addresses)
@@ -65,6 +66,7 @@ void get_transport_interfaces<IPv4EndPoint>(
 }
 
 template<>
+inline
 void get_transport_interfaces<IPv6EndPoint>(
     uint16_t agent_port,
     std::vector<dds::xrce::TransportAddress>& transport_addresses)

--- a/include/uxr/agent/transport/util/InterfaceLinux.hpp
+++ b/include/uxr/agent/transport/util/InterfaceLinux.hpp
@@ -1,0 +1,114 @@
+// Copyright 2017-present Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UXR_AGENT_TRANSPORT_UTIL_INTERFACELINUX_HPP_
+#define UXR_AGENT_TRANSPORT_UTIL_INTERFACELINUX_HPP_
+
+#include <uxr/agent/types/XRCETypes.hpp>
+#include <uxr/agent/transport/endpoint/IPv4EndPoint.hpp>
+#include <uxr/agent/transport/endpoint/IPv6EndPoint.hpp>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <ifaddrs.h>
+
+namespace eprosima {
+namespace uxr {
+namespace util {
+
+template<typename E>
+void get_transport_interfaces(
+    uint16_t agent_port,
+    std::vector<dds::xrce::TransportAddress>& transport_addresses);
+
+template<>
+void get_transport_interfaces<IPv4EndPoint>(
+    uint16_t agent_port,
+    std::vector<dds::xrce::TransportAddress>& transport_addresses)
+{
+    struct ifaddrs* ifaddr;
+    struct ifaddrs* ptr;
+
+    transport_addresses.clear();
+    if (-1 != getifaddrs(&ifaddr))
+    {
+        for (ptr = ifaddr; ptr != nullptr; ptr = ptr->ifa_next)
+        {
+            if (AF_INET == ptr->ifa_addr->sa_family)
+            {
+                dds::xrce::TransportAddressMedium medium_locator;
+                medium_locator.port(agent_port);
+                medium_locator.address(
+                    {uint8_t(ptr->ifa_addr->sa_data[2]),
+                     uint8_t(ptr->ifa_addr->sa_data[3]),
+                     uint8_t(ptr->ifa_addr->sa_data[4]),
+                     uint8_t(ptr->ifa_addr->sa_data[5])});
+                transport_addresses.emplace_back();
+                transport_addresses.back().medium_locator(medium_locator);
+            }
+        }
+    }
+    freeifaddrs(ifaddr);
+}
+
+template<>
+void get_transport_interfaces<IPv6EndPoint>(
+    uint16_t agent_port,
+    std::vector<dds::xrce::TransportAddress>& transport_addresses)
+{
+    struct ifaddrs* ifaddr;
+    struct ifaddrs* ptr;
+
+    transport_addresses.clear();
+    if (-1 != getifaddrs(&ifaddr))
+    {
+        for (ptr = ifaddr; ptr != nullptr; ptr = ptr->ifa_next)
+        {
+            if (AF_INET6 == ptr->ifa_addr->sa_family)
+            {
+                dds::xrce::TransportAddressLarge large_locator;
+                large_locator.port(agent_port);
+                struct sockaddr_in6* addr = reinterpret_cast<sockaddr_in6*>(ptr->ifa_addr);
+                large_locator.address(
+                    {addr->sin6_addr.s6_addr[0],
+                     addr->sin6_addr.s6_addr[1],
+                     addr->sin6_addr.s6_addr[2],
+                     addr->sin6_addr.s6_addr[3],
+                     addr->sin6_addr.s6_addr[4],
+                     addr->sin6_addr.s6_addr[5],
+                     addr->sin6_addr.s6_addr[6],
+                     addr->sin6_addr.s6_addr[7],
+                     addr->sin6_addr.s6_addr[8],
+                     addr->sin6_addr.s6_addr[9],
+                     addr->sin6_addr.s6_addr[10],
+                     addr->sin6_addr.s6_addr[11],
+                     addr->sin6_addr.s6_addr[12],
+                     addr->sin6_addr.s6_addr[13],
+                     addr->sin6_addr.s6_addr[14],
+                     addr->sin6_addr.s6_addr[15]});
+                transport_addresses.emplace_back();
+                transport_addresses.back().large_locator(large_locator);
+            }
+        }
+    }
+    freeifaddrs(ifaddr);
+}
+
+} // namespace util
+} // namespace uxr
+} // namespace eprosima
+
+#endif // UXR_AGENT_TRANSPORT_UTIL_INTERFACELINUX_HPP_

--- a/include/uxr/agent/transport/util/InterfaceWindows.hpp
+++ b/include/uxr/agent/transport/util/InterfaceWindows.hpp
@@ -33,6 +33,7 @@ void get_transport_interfaces(
     std::vector<dds::xrce::TransportAddress>& transport_addresses);
 
 template<>
+inline
 void get_transport_interfaces<IPv4EndPoint>(
     uint16_t agent_port,
     std::vector<dds::xrce::TransportAddress>& transport_addresses)
@@ -93,6 +94,7 @@ void get_transport_interfaces<IPv4EndPoint>(
 }
 
 template<>
+inline
 void get_transport_interfaces<IPv6EndPoint>(
     uint16_t agent_port,
     std::vector<dds::xrce::TransportAddress>& transport_addresses)

--- a/include/uxr/agent/transport/util/InterfaceWindows.hpp
+++ b/include/uxr/agent/transport/util/InterfaceWindows.hpp
@@ -1,0 +1,172 @@
+// Copyright 2017-present Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UXR_AGENT_TRANSPORT_UTIL_INTERFACEWINDOWS_HPP_
+#define UXR_AGENT_TRANSPORT_UTIL_INTERFACEWINDOWS_HPP_
+
+#include <uxr/agent/types/XRCETypes.hpp>
+#include <uxr/agent/transport/endpoint/IPv4EndPoint.hpp>
+#include <uxr/agent/transport/endpoint/IPv6EndPoint.hpp>
+
+#include <ws2ipdef.h>
+#include <MSWSock.h>
+#include <iphlpapi.h>
+
+namespace eprosima {
+namespace uxr {
+namespace util {
+
+template<typename E>
+void get_transport_interfaces(
+    uint16_t agent_port,
+    std::vector<dds::xrce::TransportAddress>& transport_addresses);
+
+template<>
+void get_transport_interfaces<IPv4EndPoint>(
+    uint16_t agent_port,
+    std::vector<dds::xrce::TransportAddress>& transport_addresses)
+{
+    transport_addresses.clear();
+
+    ULONG flags = GAA_FLAG_INCLUDE_PREFIX;
+    ULONG family = AF_UNSPEC;
+    PIP_ADAPTER_ADDRESSES addresses = nullptr;
+    PIP_ADAPTER_ADDRESSES current_addr = nullptr;
+    PIP_ADAPTER_UNICAST_ADDRESS unicast_addr = nullptr;
+    ULONG out_buf_len = 1000; // alloc 1 KB at the begining.
+    DWORD rv_get_adapters;
+
+    addresses = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(malloc(out_buf_len));
+    if (nullptr == addresses)
+    {
+        return;
+    }
+
+    rv_get_adapters = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, addresses, &out_buf_len);
+    if (ERROR_BUFFER_OVERFLOW == rv_get_adapters)
+    {
+        addresses = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(realloc(addresses, out_buf_len));
+        if (nullptr == addresses)
+        {
+            return;
+        }
+        rv_get_adapters = GetAdaptersAddresses(family, flags, nullptr, addresses, &out_buf_len);
+    }
+
+    if (NO_ERROR == rv_get_adapters)
+    {
+        current_addr = addresses;
+        while (current_addr)
+        {
+            unicast_addr = current_addr->FirstUnicastAddress;
+            while (unicast_addr)
+            {
+                if (AF_INET == unicast_addr->Address.lpSockaddr->sa_family)
+                {
+                    dds::xrce::TransportAddressMedium medium_locator;
+                    medium_locator.port(agent_port);
+                    medium_locator.address(
+                        {uint8_t(unicast_addr->Address.lpSockaddr->sa_data[2]),
+                         uint8_t(unicast_addr->Address.lpSockaddr->sa_data[3]),
+                         uint8_t(unicast_addr->Address.lpSockaddr->sa_data[4]),
+                         uint8_t(unicast_addr->Address.lpSockaddr->sa_data[5])});
+                    transport_addresses.emplace_back();
+                    transport_addresses.back().medium_locator(medium_locator);
+                }
+                unicast_addr = unicast_addr->Next;
+            }
+            current_addr = current_addr->Next;
+        }
+    }
+    free(addresses);
+}
+
+template<>
+void get_transport_interfaces<IPv6EndPoint>(
+    uint16_t agent_port,
+    std::vector<dds::xrce::TransportAddress>& transport_addresses)
+{
+    transport_addresses.clear();
+
+    ULONG flags = GAA_FLAG_INCLUDE_PREFIX;
+    ULONG family = AF_UNSPEC;
+    PIP_ADAPTER_ADDRESSES addresses = nullptr;
+    PIP_ADAPTER_ADDRESSES current_addr = nullptr;
+    PIP_ADAPTER_UNICAST_ADDRESS unicast_addr = nullptr;
+    ULONG out_buf_len = 1000; // alloc 1 KB at the begining.
+    DWORD rv_get_adapters;
+
+    addresses = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(malloc(out_buf_len));
+    if (nullptr == addresses)
+    {
+        return;
+    }
+
+    rv_get_adapters = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, addresses, &out_buf_len);
+    if (ERROR_BUFFER_OVERFLOW == rv_get_adapters)
+    {
+        addresses = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(realloc(addresses, out_buf_len));
+        if (nullptr == addresses)
+        {
+            return;
+        }
+        rv_get_adapters = GetAdaptersAddresses(family, flags, nullptr, addresses, &out_buf_len);
+    }
+
+    if (NO_ERROR == rv_get_adapters)
+    {
+        current_addr = addresses;
+        while (current_addr)
+        {
+            unicast_addr = current_addr->FirstUnicastAddress;
+            while (unicast_addr)
+            {
+                if (AF_INET6 == unicast_addr->Address.lpSockaddr->sa_family)
+                {
+                    dds::xrce::TransportAddressLarge large_locator;
+                    large_locator.port(agent_port);
+                    struct sockaddr_in6* addr = reinterpret_cast<sockaddr_in6*>(unicast_addr->Address.lpSockaddr);
+                    large_locator.address(
+                        {addr->sin6_addr.s6_addr[0],
+                         addr->sin6_addr.s6_addr[1],
+                         addr->sin6_addr.s6_addr[2],
+                         addr->sin6_addr.s6_addr[3],
+                         addr->sin6_addr.s6_addr[4],
+                         addr->sin6_addr.s6_addr[5],
+                         addr->sin6_addr.s6_addr[6],
+                         addr->sin6_addr.s6_addr[7],
+                         addr->sin6_addr.s6_addr[8],
+                         addr->sin6_addr.s6_addr[9],
+                         addr->sin6_addr.s6_addr[10],
+                         addr->sin6_addr.s6_addr[11],
+                         addr->sin6_addr.s6_addr[12],
+                         addr->sin6_addr.s6_addr[13],
+                         addr->sin6_addr.s6_addr[14],
+                         addr->sin6_addr.s6_addr[15]});
+                    transport_addresses.emplace_back();
+                    transport_addresses.back().large_locator(large_locator);
+                }
+                unicast_addr = unicast_addr->Next;
+            }
+            current_addr = current_addr->Next;
+        }
+    }
+    free(addresses);
+}
+
+} // namespace util
+} // namespace uxr
+} // namespace eprosima
+
+#endif // UXR_AGENT_TRANSPORT_UTIL_INTERFACEWINDOWS_HPP_

--- a/src/cpp/transport/discovery/DiscoveryServer.cpp
+++ b/src/cpp/transport/discovery/DiscoveryServer.cpp
@@ -39,24 +39,6 @@ DiscoveryServer<EndPoint>::DiscoveryServer(
 {}
 
 template<typename EndPoint>
-bool DiscoveryServer<EndPoint>::run(
-        uint16_t discovery_port)
-{
-    std::lock_guard<std::mutex> lock(mtx_);
-
-    if (running_cond_ || !init(discovery_port))
-    {
-        return false;
-    }
-
-    /* Init thread. */
-    running_cond_ = true;
-    thread_ = std::thread(&DiscoveryServer::discovery_loop, this);
-
-    return true;
-}
-
-template<typename EndPoint>
 bool DiscoveryServer<EndPoint>::stop()
 {
     std::lock_guard<std::mutex> lock(mtx_);

--- a/src/cpp/transport/discovery/DiscoveryServerLinux.cpp
+++ b/src/cpp/transport/discovery/DiscoveryServerLinux.cpp
@@ -241,7 +241,7 @@ bool DiscoveryServerLinux<EndPoint>::recv_message(
 {
     bool rv = false;
     struct sockaddr client_addr;
-    socklen_t client_addr_len;
+    socklen_t client_addr_len = sizeof(client_addr);
 
     int poll_rv = poll(&poll_fd_, 1, timeout);
     if (0 < poll_rv)

--- a/src/cpp/transport/discovery/DiscoveryServerLinux.cpp
+++ b/src/cpp/transport/discovery/DiscoveryServerLinux.cpp
@@ -88,8 +88,6 @@ bool DiscoveryServerLinux<EndPoint>::init(
         mreq.imr_interface.s_addr = INADDR_ANY;
         if (-1 != setsockopt(poll_fd_.fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)))
         {
-
-
             DiscoveryServer<EndPoint>::discovery_port_ = discovery_port;
             rv = true;
             UXR_AGENT_LOG_INFO(

--- a/src/cpp/transport/discovery/DiscoveryServerWindows.cpp
+++ b/src/cpp/transport/discovery/DiscoveryServerWindows.cpp
@@ -24,156 +24,6 @@
 
 #define RECEIVE_TIMEOUT 100
 
-namespace {
-
-template<typename E>
-bool update_interfaces(
-    uint16_t agent_port,
-    std::vector<dds::xrce::TransportAddress>& transport_addresses);
-
-template<>
-bool update_interfaces<eprosima::uxr::IPv4EndPoint>(
-    uint16_t agent_port,
-    std::vector<dds::xrce::TransportAddress>& transport_addresses)
-{
-    bool rv = false;
-
-    ULONG flags = GAA_FLAG_INCLUDE_PREFIX;
-    ULONG family = AF_UNSPEC;
-    PIP_ADAPTER_ADDRESSES addresses = nullptr;
-    PIP_ADAPTER_ADDRESSES current_addr = nullptr;
-    PIP_ADAPTER_UNICAST_ADDRESS unicast_addr = nullptr;
-    ULONG out_buf_len = 1000; // alloc 1 KB at the begining.
-    DWORD rv_get_adapters;
-
-    addresses = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(malloc(out_buf_len));
-    if (nullptr == addresses)
-    {
-        return false;
-    }
-
-    rv_get_adapters = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, addresses, &out_buf_len);
-    if (ERROR_BUFFER_OVERFLOW == rv_get_adapters)
-    {
-        addresses = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(realloc(addresses, out_buf_len));
-        if (nullptr == addresses)
-        {
-            return false;
-        }
-        rv_get_adapters = GetAdaptersAddresses(family, flags, nullptr, addresses, &out_buf_len);
-    }
-
-    if (NO_ERROR == rv_get_adapters)
-    {
-        transport_addresses.clear();
-        current_addr = addresses;
-        while (current_addr)
-        {
-            unicast_addr = current_addr->FirstUnicastAddress;
-            while (unicast_addr)
-            {
-                if (AF_INET == unicast_addr->Address.lpSockaddr->sa_family)
-                {
-                    dds::xrce::TransportAddressMedium medium_locator;
-                    medium_locator.port(agent_port);
-                    medium_locator.address(
-                        {uint8_t(unicast_addr->Address.lpSockaddr->sa_data[2]),
-                         uint8_t(unicast_addr->Address.lpSockaddr->sa_data[3]),
-                         uint8_t(unicast_addr->Address.lpSockaddr->sa_data[4]),
-                         uint8_t(unicast_addr->Address.lpSockaddr->sa_data[5])});
-                    transport_addresses.emplace_back();
-                    transport_addresses.back().medium_locator(medium_locator);
-                }
-                unicast_addr = unicast_addr->Next;
-            }
-            current_addr = current_addr->Next;
-        }
-        rv = true;
-    }
-    free(addresses);
-
-    return rv;
-}
-
-template<>
-bool update_interfaces<eprosima::uxr::IPv6EndPoint>(
-    uint16_t agent_port,
-    std::vector<dds::xrce::TransportAddress>& transport_addresses)
-{
-    bool rv = false;
-
-    ULONG flags = GAA_FLAG_INCLUDE_PREFIX;
-    ULONG family = AF_UNSPEC;
-    PIP_ADAPTER_ADDRESSES addresses = nullptr;
-    PIP_ADAPTER_ADDRESSES current_addr = nullptr;
-    PIP_ADAPTER_UNICAST_ADDRESS unicast_addr = nullptr;
-    ULONG out_buf_len = 1000; // alloc 1 KB at the begining.
-    DWORD rv_get_adapters;
-
-    addresses = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(malloc(out_buf_len));
-    if (nullptr == addresses)
-    {
-        return false;
-    }
-
-    rv_get_adapters = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, addresses, &out_buf_len);
-    if (ERROR_BUFFER_OVERFLOW == rv_get_adapters)
-    {
-        addresses = reinterpret_cast<IP_ADAPTER_ADDRESSES*>(realloc(addresses, out_buf_len));
-        if (nullptr == addresses)
-        {
-            return false;
-        }
-        rv_get_adapters = GetAdaptersAddresses(family, flags, nullptr, addresses, &out_buf_len);
-    }
-
-    if (NO_ERROR == rv_get_adapters)
-    {
-        transport_addresses.clear();
-        current_addr = addresses;
-        while (current_addr)
-        {
-            unicast_addr = current_addr->FirstUnicastAddress;
-            while (unicast_addr)
-            {
-                if (AF_INET6 == unicast_addr->Address.lpSockaddr->sa_family)
-                {
-                    dds::xrce::TransportAddressLarge large_locator;
-                    large_locator.port(agent_port);
-                    struct sockaddr_in6* addr = reinterpret_cast<sockaddr_in6*>(unicast_addr->Address.lpSockaddr);
-                    large_locator.address(
-                        {addr->sin6_addr.s6_addr[0],
-                         addr->sin6_addr.s6_addr[1],
-                         addr->sin6_addr.s6_addr[2],
-                         addr->sin6_addr.s6_addr[3],
-                         addr->sin6_addr.s6_addr[4],
-                         addr->sin6_addr.s6_addr[5],
-                         addr->sin6_addr.s6_addr[6],
-                         addr->sin6_addr.s6_addr[7],
-                         addr->sin6_addr.s6_addr[8],
-                         addr->sin6_addr.s6_addr[9],
-                         addr->sin6_addr.s6_addr[10],
-                         addr->sin6_addr.s6_addr[11],
-                         addr->sin6_addr.s6_addr[12],
-                         addr->sin6_addr.s6_addr[13],
-                         addr->sin6_addr.s6_addr[14],
-                         addr->sin6_addr.s6_addr[15]});
-                    transport_addresses.emplace_back();
-                    transport_addresses.back().large_locator(large_locator);
-                }
-                unicast_addr = unicast_addr->Next;
-            }
-            current_addr = current_addr->Next;
-        }
-        rv = true;
-    }
-    free(addresses);
-
-    return rv;
-}
-
-} // anonymous namespace
-
 namespace eprosima {
 namespace uxr {
 
@@ -199,12 +49,6 @@ bool DiscoveryServerWindows<EndPoint>::init(
             UXR_DECORATE_RED("socket error"),
             "Port: {}",
             discovery_port);
-        return false;
-    }
-
-    /* Get interfaces. */
-    if (!update_interfaces())
-    {
         return false;
     }
 
@@ -362,14 +206,6 @@ bool DiscoveryServerWindows<EndPoint>::send_message(
     }
 
     return rv;
-}
-
-template<typename EndPoint>
-bool DiscoveryServerWindows<EndPoint>::update_interfaces()
-{
-    return ::update_interfaces<EndPoint>(
-        this->agent_port_,
-        this->transport_addresses_);
 }
 
 template class DiscoveryServerWindows<IPv4EndPoint>;

--- a/src/cpp/transport/tcp/TCPv4AgentLinux.cpp
+++ b/src/cpp/transport/tcp/TCPv4AgentLinux.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <uxr/agent/transport/tcp/TCPv4AgentLinux.hpp>
+#include <uxr/agent/transport/util/InterfaceLinux.hpp>
 #include <uxr/agent/utils/Conversion.hpp>
 #include <uxr/agent/logger/Logger.hpp>
 
@@ -198,7 +199,9 @@ bool TCPv4Agent::close()
 #ifdef UAGENT_DISCOVERY_PROFILE
 bool TCPv4Agent::init_discovery(uint16_t discovery_port)
 {
-    return discovery_server_.run(discovery_port);
+    std::vector<dds::xrce::TransportAddress> transport_addresses;
+    util::get_transport_interfaces<IPv4EndPoint>(this->agent_port_, transport_addresses);
+    return discovery_server_.run(discovery_port, transport_addresses);
 }
 
 bool TCPv4Agent::close_discovery()

--- a/src/cpp/transport/tcp/TCPv4AgentWindows.cpp
+++ b/src/cpp/transport/tcp/TCPv4AgentWindows.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <uxr/agent/transport/tcp/TCPv4AgentWindows.hpp>
+#include <uxr/agent/transport/util/InterfaceWindows.hpp>
 #include <uxr/agent/utils/Conversion.hpp>
 #include <uxr/agent/logger/Logger.hpp>
 
@@ -187,7 +188,9 @@ bool TCPv4Agent::close()
 #ifdef UAGENT_DISCOVERY_PROFILE
 bool TCPv4Agent::init_discovery(uint16_t discovery_port)
 {
-    return discovery_server_.run(discovery_port);
+    std::vector<dds::xrce::TransportAddress> transport_addresses;
+    util::get_transport_interfaces<IPv4EndPoint>(this->agent_port_, transport_addresses);
+    return discovery_server_.run(discovery_port, transport_addresses);
 }
 
 bool TCPv4Agent::close_discovery()

--- a/src/cpp/transport/tcp/TCPv6AgentLinux.cpp
+++ b/src/cpp/transport/tcp/TCPv6AgentLinux.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <uxr/agent/transport/tcp/TCPv6AgentLinux.hpp>
+#include <uxr/agent/transport/util/InterfaceLinux.hpp>
 #include <uxr/agent/utils/Conversion.hpp>
 #include <uxr/agent/logger/Logger.hpp>
 
@@ -200,7 +201,9 @@ bool TCPv6Agent::close()
 bool TCPv6Agent::init_discovery(
         uint16_t discovery_port)
 {
-    return discovery_server_.run(discovery_port);
+    std::vector<dds::xrce::TransportAddress> transport_addresses;
+    util::get_transport_interfaces<IPv6EndPoint>(this->agent_port_, transport_addresses);
+    return discovery_server_.run(discovery_port, transport_addresses);
 }
 
 bool TCPv6Agent::close_discovery()

--- a/src/cpp/transport/tcp/TCPv6AgentWindows.cpp
+++ b/src/cpp/transport/tcp/TCPv6AgentWindows.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <uxr/agent/transport/tcp/TCPv6AgentWindows.hpp>
+#include <uxr/agent/transport/util/InterfaceWindows.hpp>
 #include <uxr/agent/utils/Conversion.hpp>
 #include <uxr/agent/logger/Logger.hpp>
 
@@ -186,7 +187,9 @@ bool TCPv6Agent::close()
 #ifdef UAGENT_DISCOVERY_PROFILE
 bool TCPv6Agent::init_discovery(uint16_t discovery_port)
 {
-    return discovery_server_.run(discovery_port);
+    std::vector<dds::xrce::TransportAddress> transport_addresses;
+    util::get_transport_interfaces<IPv6EndPoint>(this->agent_port_, transport_addresses);
+    return discovery_server_.run(discovery_port, transport_addresses);
 }
 
 bool TCPv6Agent::close_discovery()

--- a/src/cpp/transport/udp/UDPv4AgentLinux.cpp
+++ b/src/cpp/transport/udp/UDPv4AgentLinux.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <uxr/agent/transport/udp/UDPv4AgentLinux.hpp>
+#include <uxr/agent/transport/util/InterfaceLinux.hpp>
 #include <uxr/agent/utils/Conversion.hpp>
 #include <uxr/agent/logger/Logger.hpp>
 
@@ -139,7 +140,9 @@ bool UDPv4Agent::close()
 #ifdef UAGENT_DISCOVERY_PROFILE
 bool UDPv4Agent::init_discovery(uint16_t discovery_port)
 {
-    return discovery_server_.run(discovery_port);
+    std::vector<dds::xrce::TransportAddress> transport_addresses;
+    util::get_transport_interfaces<IPv4EndPoint>(this->agent_port_, transport_addresses);
+    return discovery_server_.run(discovery_port, transport_addresses);
 }
 
 bool UDPv4Agent::close_discovery()

--- a/src/cpp/transport/udp/UDPv4AgentWindows.cpp
+++ b/src/cpp/transport/udp/UDPv4AgentWindows.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <uxr/agent/transport/udp/UDPv4AgentWindows.hpp>
+#include <uxr/agent/transport/util/InterfaceWindows.hpp>
 #include <uxr/agent/utils/Conversion.hpp>
 #include <uxr/agent/logger/Logger.hpp>
 
@@ -132,7 +133,9 @@ bool UDPv4Agent::close()
 #ifdef UAGENT_DISCOVERY_PROFILE
 bool UDPv4Agent::init_discovery(uint16_t discovery_port)
 {
-    return discovery_server_.run(discovery_port);
+    std::vector<dds::xrce::TransportAddress> transport_addresses;
+    util::get_transport_interfaces<IPv4EndPoint>(this->agent_port_, transport_addresses);
+    return discovery_server_.run(discovery_port, transport_addresses);
 }
 
 bool UDPv4Agent::close_discovery()

--- a/src/cpp/transport/udp/UDPv6AgentLinux.cpp
+++ b/src/cpp/transport/udp/UDPv6AgentLinux.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <uxr/agent/transport/udp/UDPv6AgentLinux.hpp>
+#include <uxr/agent/transport/util/InterfaceLinux.hpp>
 #include <uxr/agent/utils/Conversion.hpp>
 #include <uxr/agent/logger/Logger.hpp>
 
@@ -141,7 +142,9 @@ bool UDPv6Agent::close()
 bool UDPv6Agent::init_discovery(
         uint16_t discovery_port)
 {
-    return discovery_server_.run(discovery_port);
+    std::vector<dds::xrce::TransportAddress> transport_addresses;
+    util::get_transport_interfaces<IPv6EndPoint>(this->agent_port_, transport_addresses);
+    return discovery_server_.run(discovery_port, std::move(transport_addresses));
 }
 
 bool UDPv6Agent::close_discovery()

--- a/src/cpp/transport/udp/UDPv6AgentWindows.cpp
+++ b/src/cpp/transport/udp/UDPv6AgentWindows.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <uxr/agent/transport/udp/UDPv6AgentWindows.hpp>
+#include <uxr/agent/transport/util/InterfaceWindows.hpp>
 #include <uxr/agent/utils/Conversion.hpp>
 #include <uxr/agent/logger/Logger.hpp>
 
@@ -133,7 +134,9 @@ bool UDPv6Agent::close()
 #ifdef UAGENT_DISCOVERY_PROFILE
 bool UDPv6Agent::init_discovery(uint16_t discovery_port)
 {
-    return discovery_server_.run(discovery_port);
+    std::vector<dds::xrce::TransportAddress> transport_addresses;
+    util::get_transport_interfaces<IPv4EndPoint>(this->agent_port_, transport_addresses);
+    return discovery_server_.run(discovery_port, transport_addresses);
 }
 
 bool UDPv6Agent::close_discovery()


### PR DESCRIPTION
This PR modifies the `DiscoveryServer` approach.
Now, Agents such as `UDPv4Agent` are in charge of obtains the list of network interfaces and passing them to the `DiscoveryServer`.