### PR TITLE
P2P refactor

### DIFF
--- a/include/uxr/agent/p2p/InternalClientManager.hpp
+++ b/include/uxr/agent/p2p/InternalClientManager.hpp
@@ -33,7 +33,6 @@ public:
     static InternalClientManager& instance();
 
     void set_local_address(
-            const std::array<uint8_t, 4>& ip,
             uint16_t port);
 
     void create_client(

--- a/include/uxr/agent/transport/p2p/AgentDiscoverer.hpp
+++ b/include/uxr/agent/transport/p2p/AgentDiscoverer.hpp
@@ -39,21 +39,17 @@ public:
     AgentDiscoverer& operator=(AgentDiscoverer&&) = delete;
     AgentDiscoverer& operator=(const AgentDiscoverer&) = delete;
 
-    bool run(
+    bool start(
             uint16_t p2p_port,
-            const dds::xrce::TransportAddress& local_address);
+            uint16_t agent_port);
 
     bool stop();
-
-    void set_local_address(
-            const std::array<uint8_t, 4>& ip,
-            uint16_t port);
 
 private:
     virtual bool init(
             uint16_t p2p_port) = 0;
 
-    virtual bool close() = 0;
+    virtual bool fini() = 0;
 
     virtual bool recv_message(
             InputMessagePtr& input_message,

--- a/include/uxr/agent/transport/p2p/AgentDiscovererLinux.hpp
+++ b/include/uxr/agent/transport/p2p/AgentDiscovererLinux.hpp
@@ -34,7 +34,7 @@ private:
     bool init(
             uint16_t p2p_port) final;
 
-    bool close() final;
+    bool fini() final;
 
     bool recv_message(
             InputMessagePtr& input_message,

--- a/include/uxr/agent/transport/tcp/TCPv4AgentLinux.hpp
+++ b/include/uxr/agent/transport/tcp/TCPv4AgentLinux.hpp
@@ -20,9 +20,6 @@
 #ifdef UAGENT_DISCOVERY_PROFILE
 #include <uxr/agent/transport/discovery/DiscoveryServerLinux.hpp>
 #endif
-#ifdef UAGENT_P2P_PROFILE
-#include <uxr/agent/transport/p2p/AgentDiscovererLinux.hpp>
-#endif
 
 #include <netinet/in.h>
 #include <sys/poll.h>
@@ -126,9 +123,6 @@ private:
     std::queue<InputPacket<IPv4EndPoint>> messages_queue_;
 #ifdef UAGENT_DISCOVERY_PROFILE
     DiscoveryServerLinux<IPv4EndPoint> discovery_server_;
-#endif
-#ifdef UAGENT_P2P_PROFILE
-    AgentDiscovererLinux agent_discoverer_;
 #endif
 };
 

--- a/include/uxr/agent/transport/tcp/TCPv6AgentLinux.hpp
+++ b/include/uxr/agent/transport/tcp/TCPv6AgentLinux.hpp
@@ -20,9 +20,6 @@
 #ifdef UAGENT_DISCOVERY_PROFILE
 #include <uxr/agent/transport/discovery/DiscoveryServerLinux.hpp>
 #endif
-#ifdef UAGENT_P2P_PROFILE
-#include <uxr/agent/transport/p2p/AgentDiscovererLinux.hpp>
-#endif
 
 #include <netinet/in.h>
 #include <sys/poll.h>
@@ -127,9 +124,6 @@ private:
     std::queue<InputPacket<IPv6EndPoint>> messages_queue_;
 #ifdef UAGENT_DISCOVERY_PROFILE
     DiscoveryServerLinux<IPv6EndPoint> discovery_server_;
-#endif
-#ifdef UAGENT_P2P_PROFILE
-    AgentDiscovererLinux agent_discoverer_;
 #endif
 };
 

--- a/include/uxr/agent/transport/udp/UDPv6AgentLinux.hpp
+++ b/include/uxr/agent/transport/udp/UDPv6AgentLinux.hpp
@@ -20,9 +20,6 @@
 #ifdef UAGENT_DISCOVERY_PROFILE
 #include <uxr/agent/transport/discovery/DiscoveryServerLinux.hpp>
 #endif
-#ifdef UAGENT_P2P_PROFILE
-#include <uxr/agent/transport/p2p/AgentDiscovererLinux.hpp>
-#endif
 
 #include <cstdint>
 #include <cstddef>
@@ -78,9 +75,6 @@ private:
     uint16_t agent_port_;
 #ifdef UAGENT_DISCOVERY_PROFILE
     DiscoveryServerLinux<IPv6EndPoint> discovery_server_;
-#endif
-#ifdef UAGENT_P2P_PROFILE
-    AgentDiscovererLinux agent_discoverer_;
 #endif
 };
 

--- a/src/cpp/p2p/InternalClient.cpp
+++ b/src/cpp/p2p/InternalClient.cpp
@@ -15,6 +15,7 @@
 #include <uxr/agent/p2p/InternalClient.hpp>
 #include <uxr/agent/middleware/ced/CedEntities.hpp>
 #include <uxr/agent/Agent.hpp>
+#include <uxr/agent/logger/Logger.hpp>
 #include <ucdr/microcdr.h>
 
 #include <string>
@@ -46,14 +47,7 @@ InternalClient::InternalClient(
     , in_stream_id_{}
     , running_cond_{false}
     , thread_{}
-{
-    std::cout << "--> OK: created InternalClient at address ";
-    std::cout << int(ip[0]) << ".";
-    std::cout << int(ip[1]) << ".";
-    std::cout << int(ip[2]) << ".";
-    std::cout << int(ip[3]) << ":";
-    std::cout << port << std::endl;
-}
+{}
 
 static void on_topic(
         uxrSession* session,
@@ -117,19 +111,29 @@ bool InternalClient::run()
                 /* Create streams. */
                 create_streams();
 
-                std::cout << "--> OK: running InternalClient" << std::endl;
+                UXR_AGENT_LOG_INFO(
+                    UXR_DECORATE_GREEN("connected to Agent"),
+                    "address: {}:{}",
+                    ip, port);
+
                 running_cond_ = true;
                 thread_ = std::thread(&InternalClient::loop, this);
                 rv = true;
             }
             else
             {
-                std::cerr << "--> ERROR: failed to create session in InternalClient" << std::endl;
+                UXR_AGENT_LOG_INFO(
+                    UXR_DECORATE_RED("failed to create session with Agent"),
+                    "address: {}:{}",
+                    ip, port);
             }
         }
         else
         {
-            std::cerr << "--> ERROR: failed to create transport in InternalClient" << std::endl;
+            UXR_AGENT_LOG_INFO(
+                UXR_DECORATE_RED("failed to init transport with Agent"),
+                "address: {}:{}",
+                ip, port);
         }
     }
 

--- a/src/cpp/p2p/InternalClientManager.cpp
+++ b/src/cpp/p2p/InternalClientManager.cpp
@@ -27,10 +27,9 @@ InternalClientManager& InternalClientManager::instance()
 }
 
 void InternalClientManager::set_local_address(
-        const std::array<uint8_t, 4>& ip,
         uint16_t port)
 {
-    local_client_key_ = port + (uint32_t(ip[3]) << 16) + (uint32_t(0xEA) << 24);
+    local_client_key_ = port + (uint32_t(0xEA) << 24);
 }
 
 void InternalClientManager::create_client(

--- a/src/cpp/transport/p2p/AgentDiscoverer.cpp
+++ b/src/cpp/transport/p2p/AgentDiscoverer.cpp
@@ -26,9 +26,9 @@ AgentDiscoverer::AgentDiscoverer(
     , running_cond_{false}
 {}
 
-bool AgentDiscoverer::run(
+bool AgentDiscoverer::start(
         uint16_t p2p_port,
-        const dds::xrce::TransportAddress& local_address)
+        uint16_t agent_port)
 {
     std::lock_guard<std::mutex> lock(mtx_);
 
@@ -37,21 +37,11 @@ bool AgentDiscoverer::run(
         return false;
     }
 
-    bool rv = false;
-
-    /* Set local address in InternalClientManager. */
     InternalClientManager& manager = InternalClientManager::instance();
-    if (dds::xrce::ADDRESS_FORMAT_MEDIUM == local_address._d())
-    {
-        manager.set_local_address(local_address.medium_locator().address(), local_address.medium_locator().port());
-
-        /* Init thread. */
-        running_cond_ = true;
-        thread_ = std::thread(&AgentDiscoverer::loop, this);
-        rv = true;
-    }
-
-    return rv;
+    manager.set_local_address(agent_port);
+    thread_ = std::thread(&AgentDiscoverer::loop, this);
+    running_cond_ = true;
+    return true;
 }
 
 bool AgentDiscoverer::stop()
@@ -68,15 +58,7 @@ bool AgentDiscoverer::stop()
     InternalClientManager& manager = InternalClientManager::instance();
     manager.delete_clients();
 
-    return close();
-}
-
-void AgentDiscoverer::set_local_address(
-        const std::array<uint8_t, 4>& ip,
-        uint16_t port)
-{
-    InternalClientManager& manager = InternalClientManager::instance();
-    manager.set_local_address(ip, port);
+    return fini();
 }
 
 void AgentDiscoverer::loop()

--- a/src/cpp/transport/p2p/AgentDiscovererLinux.cpp
+++ b/src/cpp/transport/p2p/AgentDiscovererLinux.cpp
@@ -72,7 +72,7 @@ bool AgentDiscovererLinux::init(
     return rv;
 }
 
-bool AgentDiscovererLinux::close()
+bool AgentDiscovererLinux::fini()
 {
     return (-1 == poll_fd_.fd) || (0 == ::close(poll_fd_.fd));
 }

--- a/src/cpp/transport/tcp/TCPv4AgentLinux.cpp
+++ b/src/cpp/transport/tcp/TCPv4AgentLinux.cpp
@@ -52,9 +52,6 @@ TCPv4Agent::TCPv4Agent(
 #ifdef UAGENT_DISCOVERY_PROFILE
     , discovery_server_{*processor_}
 #endif
-#ifdef UAGENT_P2P_PROFILE
-    , agent_discoverer_{*this}
-#endif
 {}
 
 TCPv4Agent::~TCPv4Agent()
@@ -212,20 +209,16 @@ bool TCPv4Agent::fini_discovery()
 #endif
 
 #ifdef UAGENT_P2P_PROFILE
-bool TCPv4Agent::init_p2p(uint16_t p2p_port)
+bool TCPv4Agent::init_p2p(uint16_t /*p2p_port*/)
 {
-#ifdef UAGENT_DISCOVERY_PROFILE
-    discovery_server_.set_filter_port(p2p_port);
-#endif
+    // TODO (julibert): implement TCP InternalClient.
     return true;
 }
 
 bool TCPv4Agent::fini_p2p()
 {
-#ifdef UAGENT_DISCOVERY_PROFILE
-    discovery_server_.set_filter_port(0);
-#endif
-    return agent_discoverer_.stop();
+    // TODO (julibert): implement TCP InternalClient.
+    return true;
 }
 #endif
 

--- a/src/cpp/transport/tcp/TCPv6AgentLinux.cpp
+++ b/src/cpp/transport/tcp/TCPv6AgentLinux.cpp
@@ -52,9 +52,6 @@ TCPv6Agent::TCPv6Agent(
 #ifdef UAGENT_DISCOVERY_PROFILE
     , discovery_server_{*processor_}
 #endif
-#ifdef UAGENT_P2P_PROFILE
-    , agent_discoverer_{*this}
-#endif
 {}
 
 TCPv6Agent::~TCPv6Agent()
@@ -214,20 +211,16 @@ bool TCPv6Agent::fini_discovery()
 #endif
 
 #ifdef UAGENT_P2P_PROFILE
-bool TCPv6Agent::init_p2p(uint16_t p2p_port)
+bool TCPv6Agent::init_p2p(uint16_t /*p2p_port*/)
 {
-#ifdef UAGENT_DISCOVERY_PROFILE
-    discovery_server_.set_filter_port(p2p_port);
-#endif
+    // TODO (julibert): implement TCP InternalClient.
     return true;
 }
 
 bool TCPv6Agent::fini_p2p()
 {
-#ifdef UAGENT_DISCOVERY_PROFILE
-    discovery_server_.set_filter_port(0);
-#endif
-    return agent_discoverer_.stop();
+    // TODO (julibert): implement TCP InternalClient.
+    return true;
 }
 #endif
 

--- a/src/cpp/transport/udp/UDPv4AgentLinux.cpp
+++ b/src/cpp/transport/udp/UDPv4AgentLinux.cpp
@@ -157,8 +157,7 @@ bool UDPv4Agent::init_p2p(uint16_t p2p_port)
 #ifdef UAGENT_DISCOVERY_PROFILE
     discovery_server_.set_filter_port(p2p_port);
 #endif
-//    return agent_discoverer_.run(p2p_port, transport_address_);
-    return true; // TODO.
+    return agent_discoverer_.start(p2p_port, agent_port_);
 }
 
 bool UDPv4Agent::fini_p2p()

--- a/src/cpp/transport/udp/UDPv6AgentLinux.cpp
+++ b/src/cpp/transport/udp/UDPv6AgentLinux.cpp
@@ -41,9 +41,6 @@ UDPv6Agent::UDPv6Agent(
 #ifdef UAGENT_DISCOVERY_PROFILE
     , discovery_server_{*processor_}
 #endif
-#ifdef UAGENT_P2P_PROFILE
-    , agent_discoverer_{*this}
-#endif
 {}
 
 UDPv6Agent::~UDPv6Agent()
@@ -153,21 +150,16 @@ bool UDPv6Agent::fini_discovery()
 #endif
 
 #ifdef UAGENT_P2P_PROFILE
-bool UDPv6Agent::init_p2p(uint16_t p2p_port)
+bool UDPv6Agent::init_p2p(uint16_t /*p2p_port*/)
 {
-#ifdef UAGENT_DISCOVERY_PROFILE
-    discovery_server_.set_filter_port(p2p_port);
-#endif
-//    return agent_discoverer_.run(p2p_port, transport_address_);
-    return true; // TODO.
+    // TODO (julibert): implement UDP/IPv6 InternalClient.
+    return true;
 }
 
 bool UDPv6Agent::fini_p2p()
 {
-#ifdef UAGENT_DISCOVERY_PROFILE
-    discovery_server_.set_filter_port(0);
-#endif
-    return agent_discoverer_.stop();
+    // TODO (julibert): implement UDP/IPv6 InternalClient.
+    return true;
 }
 #endif
 


### PR DESCRIPTION
This PR refactors P2P server.
First, P2P was removed from TCP and UDPv6 server, where there is not available implementation.
Second, the server interface methods were renamed with a more apropiate approach.