### PR TITLE
Fix termios speed settings according to the POSIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 ###############################################################################
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 if(NOT UAGENT_SUPERBUILD)
-    project(microxrcedds_agent VERSION "1.3.0" LANGUAGES C CXX)
+    project(microxrcedds_agent VERSION "1.3.1" LANGUAGES C CXX)
 else()
     project(uagent_superbuild NONE)
     include(${PROJECT_SOURCE_DIR}/cmake/SuperBuild.cmake)

--- a/src/cpp/transport/serial/TermiosAgentLinux.cpp
+++ b/src/cpp/transport/serial/TermiosAgentLinux.cpp
@@ -63,8 +63,9 @@ bool TermiosAgent::init()
             new_attrs.c_oflag = termios_attrs_.c_oflag;
             new_attrs.c_cc[VMIN] = termios_attrs_.c_cc[VMIN];
             new_attrs.c_cc[VTIME] = termios_attrs_.c_cc[VTIME];
-            new_attrs.c_ispeed = termios_attrs_.c_ispeed;
-            new_attrs.c_ospeed = termios_attrs_.c_ospeed;
+
+            cfsetispeed(&new_attrs, termios_attrs_.c_ispeed);
+            cfsetospeed(&new_attrs, termios_attrs_.c_ospeed);
 
             if (0 == tcsetattr(poll_fd_.fd, TCSANOW, &new_attrs))
             {


### PR DESCRIPTION
According to the POSIX, you need to use cfsetispeed/cfsetospeed instead of working with raw termios struct. 
This PR fixed https://github.com/micro-ROS/micro-ros-build/issues/107