### PR TITLE
Refactor FastRTPS entities

### DIFF
--- a/include/uxr/agent/middleware/fast/FastEntities.hpp
+++ b/include/uxr/agent/middleware/fast/FastEntities.hpp
@@ -193,8 +193,6 @@ public:
     bool write(
             const std::vector<uint8_t>& data);
 
-    const fastrtps::Publisher* get_ptr() const { return impl_; }
-
 private:
     fastrtps::Publisher* impl_;
     std::shared_ptr<FastTopic> topic_;
@@ -204,42 +202,27 @@ private:
 /**********************************************************************************************************************
  * FastDataReader
  **********************************************************************************************************************/
-class FastDataReader : public fastrtps::SubscriberListener
+class FastDataReader
 {
 public:
-    FastDataReader(const std::shared_ptr<FastParticipant>& participant);
+    FastDataReader(
+            fastrtps::Subscriber* impl_,
+            const std::shared_ptr<FastTopic>& topic,
+            const std::shared_ptr<FastParticipant>& participant);
 
-    ~FastDataReader() override;
+    ~FastDataReader();
 
-    bool create_by_ref(
-            const std::string& ref);
-
-    bool create_by_attributes(
-            const fastrtps::SubscriberAttributes& attrs);
-
-    bool match_from_ref(const std::string& ref) const;
-
-    bool match_from_xml(const std::string& xml) const;
+    bool match(
+            const fastrtps::SubscriberAttributes& attrs) const;
 
     bool read(
             std::vector<uint8_t>& data,
             std::chrono::milliseconds timeout);
 
-    void onSubscriptionMatched(
-            fastrtps::Subscriber* sub,
-            fastrtps::rtps::MatchingInfo& info) override;
-
-    void onNewDataMessage(fastrtps::Subscriber*) override;
-
-    const fastrtps::Subscriber* get_ptr() const { return ptr_; }
-
 private:
-    std::shared_ptr<FastParticipant> participant_;
+    fastrtps::Subscriber* impl_;
     std::shared_ptr<FastTopic> topic_;
-    fastrtps::Subscriber* ptr_;
-    std::mutex mtx_;
-    std::condition_variable cv_;
-    std::atomic<uint64_t> unread_count_;
+    std::shared_ptr<FastParticipant> participant_;
 };
 
 

--- a/include/uxr/agent/middleware/fast/FastEntities.hpp
+++ b/include/uxr/agent/middleware/fast/FastEntities.hpp
@@ -150,13 +150,17 @@ private:
 class FastPublisher
 {
 public:
-    FastPublisher(uint16_t participant_id) : participant_id_(participant_id) {}
+    FastPublisher(
+            const std::shared_ptr<FastParticipant>& participant)
+        : participant_(participant)
+    {}
+
     ~FastPublisher() = default;
 
-    uint16_t get_participant_id() { return participant_id_; }
+    const std::shared_ptr<FastParticipant>& get_participant() const { return participant_; }
 
 private:
-    uint16_t participant_id_;
+        std::shared_ptr<FastParticipant> participant_;
 };
 
 /**********************************************************************************************************************
@@ -165,13 +169,17 @@ private:
 class FastSubscriber
 {
 public:
-    FastSubscriber(uint16_t participant_id) : participant_id_(participant_id) {}
+    FastSubscriber(
+            const std::shared_ptr<FastParticipant>& participant)
+        : participant_(participant)
+    {}
+
     ~FastSubscriber() = default;
 
-    uint16_t get_participant_id() { return participant_id_; }
+    const std::shared_ptr<FastParticipant>& get_participant() const { return participant_; }
 
 private:
-    uint16_t participant_id_;
+        std::shared_ptr<FastParticipant> participant_;
 };
 
 /**********************************************************************************************************************

--- a/include/uxr/agent/middleware/fast/FastEntities.hpp
+++ b/include/uxr/agent/middleware/fast/FastEntities.hpp
@@ -280,27 +280,17 @@ private:
 /**********************************************************************************************************************
  * FastReplier
  **********************************************************************************************************************/
-class FastReplier : public fastrtps::SubscriberListener, public fastrtps::PublisherListener
+class FastReplier
 {
 public:
     FastReplier(
-            const std::shared_ptr<FastParticipant>& participant,
-            const std::shared_ptr<FastTopic>& request_topic,
-            const std::shared_ptr<FastTopic>& reply_topic);
+            const std::shared_ptr<FastDataWriter>& datawriter,
+            const std::shared_ptr<FastDataReader>& datareader);
 
-    ~FastReplier() override;
+    ~FastReplier() = default;
 
-    bool create_by_ref(
-            const std::string& ref);
-
-    bool create_by_attributes(
-            const fastrtps::ReplierAttributes& attrs);
-
-    bool match_from_ref(
-            const std::string& ref) const;
-
-    bool match_from_xml(
-            const std::string& xml) const;
+    bool match(
+            const fastrtps::ReplierAttributes& attrs) const;
 
     bool write(
             const std::vector<uint8_t>& data);
@@ -308,30 +298,9 @@ public:
     bool read(
             std::vector<uint8_t>& data,
             std::chrono::milliseconds timeout);
-
-    void onPublicationMatched(
-            fastrtps::Publisher*,
-            fastrtps::rtps::MatchingInfo& info) override;
-
-    void onSubscriptionMatched(
-            fastrtps::Subscriber* sub,
-            fastrtps::rtps::MatchingInfo& info) override;
-
-    void onNewDataMessage(
-            fastrtps::Subscriber*) override;
-
 private:
-    bool match(const fastrtps::ReplierAttributes& attrs) const;
-
-private:
-    std::shared_ptr<FastParticipant> participant_;
-    std::shared_ptr<FastTopic> request_topic_;
-    std::shared_ptr<FastTopic> reply_topic_;
-    fastrtps::Publisher* publisher_ptr_;
-    fastrtps::Subscriber* subscriber_ptr_;
-    std::mutex mtx_;
-    std::condition_variable cv_;
-    std::atomic<uint64_t> unread_count_;
+    std::shared_ptr<FastDataWriter> datawriter_;
+    std::shared_ptr<FastDataReader> datareader_;
 };
 
 } // namespace uxr

--- a/include/uxr/agent/middleware/fast/FastEntities.hpp
+++ b/include/uxr/agent/middleware/fast/FastEntities.hpp
@@ -68,31 +68,17 @@ public:
 /**********************************************************************************************************************
  * FastParticipant
  **********************************************************************************************************************/
-class FastParticipant : public fastrtps::ParticipantListener
+class FastParticipant
 {
 public:
-    FastParticipant(int16_t domain_id)
-        : domain_id_(domain_id)
-        , ptr_(nullptr)
-        , type_register_{}
-        , topic_register_{}
-    {}
+    FastParticipant(fastrtps::Participant* impl);
 
-    ~FastParticipant() override;
+    ~FastParticipant();
 
-    bool create_by_ref(const std::string& ref);
+    bool match(
+            const fastrtps::ParticipantAttributes& attrs) const;
 
-    bool create_by_attributes(const fastrtps::ParticipantAttributes& attrs);
-
-    bool match_from_ref(const std::string& ref) const;
-
-    bool match_from_xml(const std::string& xml) const;
-
-    void onParticipantDiscovery(
-            fastrtps::Participant*,
-            fastrtps::rtps::ParticipantDiscoveryInfo&& info) override;
-
-    fastrtps::Participant* get_ptr() const { return ptr_; }
+    fastrtps::Participant* get_ptr() const { return impl_; }
 
     bool register_type(
             const std::shared_ptr<FastType>& type);
@@ -112,11 +98,10 @@ public:
     std::shared_ptr<FastTopic> find_topic(
             const std::string& topic_name) const;
 
-    int16_t domain_id() const { return domain_id_; }
+    int16_t domain_id() const;
 
 private:
-    int16_t domain_id_;
-    fastrtps::Participant* ptr_;
+    fastrtps::Participant* impl_;
     std::unordered_map<std::string, std::weak_ptr<FastType>> type_register_;
     std::unordered_map<std::string, std::weak_ptr<FastTopic>> topic_register_;
 };

--- a/include/uxr/agent/middleware/fast/FastEntities.hpp
+++ b/include/uxr/agent/middleware/fast/FastEntities.hpp
@@ -135,7 +135,8 @@ public:
 
     const std::shared_ptr<FastType>& get_type() const { return type_; }
 
-    bool match(const fastrtps::TopicAttributes& attrs) const;
+    bool match(
+            const fastrtps::TopicAttributes& attrs) const;
 
 private:
     std::string name_;
@@ -176,33 +177,28 @@ private:
 /**********************************************************************************************************************
  * FastDataWriter
  **********************************************************************************************************************/
-class FastDataWriter : public fastrtps::PublisherListener
+class FastDataWriter
 {
 public:
-    FastDataWriter(const std::shared_ptr<FastParticipant>& participant);
+    FastDataWriter(
+            fastrtps::Publisher* impl_,
+            const std::shared_ptr<FastTopic>& topic,
+            const std::shared_ptr<FastParticipant>& participant);
 
-    ~FastDataWriter() override;
+    ~FastDataWriter();
 
-    bool create_by_ref(
-            const std::string& ref);
+    bool match(
+            const fastrtps::PublisherAttributes& attrs) const;
 
-    bool create_by_attributes(
-            const fastrtps::PublisherAttributes& attrs);
+    bool write(
+            const std::vector<uint8_t>& data);
 
-    bool match(const fastrtps::PublisherAttributes& attrs) const;
-
-    bool write(const std::vector<uint8_t>& data);
-
-    void onPublicationMatched(
-            fastrtps::Publisher*,
-            fastrtps::rtps::MatchingInfo& info) override;
-
-    const fastrtps::Publisher* get_ptr() const { return ptr_; }
+    const fastrtps::Publisher* get_ptr() const { return impl_; }
 
 private:
-    std::shared_ptr<FastParticipant> participant_;
+    fastrtps::Publisher* impl_;
     std::shared_ptr<FastTopic> topic_;
-    fastrtps::Publisher* ptr_;
+    std::shared_ptr<FastParticipant> participant_;
 };
 
 /**********************************************************************************************************************

--- a/include/uxr/agent/middleware/fast/FastEntities.hpp
+++ b/include/uxr/agent/middleware/fast/FastEntities.hpp
@@ -68,8 +68,7 @@ public:
 /**********************************************************************************************************************
  * FastParticipant
  **********************************************************************************************************************/
-class FastParticipant : public fastrtps::ParticipantListener,
-                        public std::enable_shared_from_this<FastParticipant>
+class FastParticipant : public fastrtps::ParticipantListener
 {
 public:
     FastParticipant(int16_t domain_id)

--- a/include/uxr/agent/middleware/fast/FastEntities.hpp
+++ b/include/uxr/agent/middleware/fast/FastEntities.hpp
@@ -191,7 +191,7 @@ public:
     FastDataWriter(
             fastrtps::Publisher* impl_,
             const std::shared_ptr<FastTopic>& topic,
-            const std::shared_ptr<FastParticipant>& participant);
+            const std::shared_ptr<FastPublisher>& publisher);
 
     ~FastDataWriter();
 
@@ -204,7 +204,7 @@ public:
 private:
     fastrtps::Publisher* impl_;
     std::shared_ptr<FastTopic> topic_;
-    std::shared_ptr<FastParticipant> participant_;
+    std::shared_ptr<FastPublisher> publisher_;
 };
 
 /**********************************************************************************************************************
@@ -216,7 +216,7 @@ public:
     FastDataReader(
             fastrtps::Subscriber* impl_,
             const std::shared_ptr<FastTopic>& topic,
-            const std::shared_ptr<FastParticipant>& participant);
+            const std::shared_ptr<FastSubscriber>& Subscriber);
 
     ~FastDataReader();
 
@@ -230,7 +230,7 @@ public:
 private:
     fastrtps::Subscriber* impl_;
     std::shared_ptr<FastTopic> topic_;
-    std::shared_ptr<FastParticipant> participant_;
+    std::shared_ptr<FastSubscriber> subscriber_;
 };
 
 

--- a/include/uxr/agent/middleware/fast/FastEntities.hpp
+++ b/include/uxr/agent/middleware/fast/FastEntities.hpp
@@ -45,6 +45,27 @@ class FastType;
 class FastTopic;
 
 /**********************************************************************************************************************
+ * Listeners
+ **********************************************************************************************************************/
+class FastListener : public fastrtps::ParticipantListener
+                   , public fastrtps::PublisherListener
+                   , public fastrtps::SubscriberListener
+{
+public:
+    void onParticipantDiscovery(
+        fastrtps::Participant*,
+        fastrtps::rtps::ParticipantDiscoveryInfo&& info) final;
+
+    void onPublicationMatched(
+        fastrtps::Publisher*,
+        fastrtps::rtps::MatchingInfo& info) final;
+
+    void onSubscriptionMatched(
+        fastrtps::Subscriber*,
+        fastrtps::rtps::MatchingInfo& info) final;
+};
+
+/**********************************************************************************************************************
  * FastParticipant
  **********************************************************************************************************************/
 class FastParticipant : public fastrtps::ParticipantListener,

--- a/include/uxr/agent/middleware/fast/FastEntities.hpp
+++ b/include/uxr/agent/middleware/fast/FastEntities.hpp
@@ -34,6 +34,7 @@ class PublisherAttributes;
 class SubscriberAttributes;
 class RequesterAttributes;
 class ReplierAttributes;
+class SampleInfo_t;
 
 } // namespace fastrtps
 } // namespace eprosima
@@ -201,6 +202,12 @@ public:
     bool write(
             const std::vector<uint8_t>& data);
 
+    bool write(
+            const std::vector<uint8_t>& data,
+            fastrtps::rtps::WriteParams& wparams);
+
+    const fastrtps::rtps::GUID_t& get_guid() const;
+
 private:
     fastrtps::Publisher* impl_;
     std::shared_ptr<FastTopic> topic_;
@@ -227,6 +234,11 @@ public:
             std::vector<uint8_t>& data,
             std::chrono::milliseconds timeout);
 
+    bool read(
+            std::vector<uint8_t>& data,
+            fastrtps::SampleInfo_t& info,
+            std::chrono::milliseconds timeout);
+
 private:
     fastrtps::Subscriber* impl_;
     std::shared_ptr<FastTopic> topic_;
@@ -237,27 +249,17 @@ private:
 /**********************************************************************************************************************
  * FastRequester
  **********************************************************************************************************************/
-class FastRequester : public fastrtps::SubscriberListener, public fastrtps::PublisherListener
+class FastRequester
 {
 public:
     FastRequester(
-            const std::shared_ptr<FastParticipant>& participant,
-            const std::shared_ptr<FastTopic>& request_topic,
-            const std::shared_ptr<FastTopic>& reply_topic);
+            const std::shared_ptr<FastDataWriter>& datawriter,
+            const std::shared_ptr<FastDataReader>& datareader);
 
-    ~FastRequester() override;
+    ~FastRequester() = default;
 
-    bool create_by_ref(
-            const std::string& ref);
-
-    bool create_by_attributes(
-            const fastrtps::RequesterAttributes& attrs);
-
-    bool match_from_ref(
-            const std::string& ref) const;
-
-    bool match_from_xml(
-            const std::string& xml) const;
+    bool match(
+            const fastrtps::RequesterAttributes& attrs) const;
 
     bool write(
             uint32_t sequence_number,
@@ -268,30 +270,10 @@ public:
             std::vector<uint8_t>& data,
             std::chrono::milliseconds timeout);
 
-    void onPublicationMatched(
-            fastrtps::Publisher*,
-            fastrtps::rtps::MatchingInfo& info) override;
-
-    void onSubscriptionMatched(
-            fastrtps::Subscriber* sub,
-            fastrtps::rtps::MatchingInfo& info) override;
-
-    void onNewDataMessage(
-            fastrtps::Subscriber*) override;
-
 private:
-    bool match(const fastrtps::RequesterAttributes& attrs) const;
-
-private:
-    std::shared_ptr<FastParticipant> participant_;
-    std::shared_ptr<FastTopic> request_topic_;
-    std::shared_ptr<FastTopic> reply_topic_;
-    fastrtps::Publisher* publisher_ptr_;
-    fastrtps::Subscriber* subscriber_ptr_;
+    std::shared_ptr<FastDataWriter> datawriter_;
+    std::shared_ptr<FastDataReader> datareader_;
     dds::GUID_t publisher_id_;
-    std::mutex mtx_;
-    std::condition_variable cv_;
-    std::atomic<uint64_t> unread_count_;
     std::map<int64_t, uint32_t> sequence_to_sequence_;
 };
 

--- a/include/uxr/agent/middleware/fast/FastMiddleware.hpp
+++ b/include/uxr/agent/middleware/fast/FastMiddleware.hpp
@@ -212,6 +212,7 @@ public:
             const std::string& xml) const override;
 
 private:
+    FastListener listener_;
     std::unordered_map<uint16_t, std::shared_ptr<FastParticipant>> participants_;
     std::unordered_map<uint16_t, std::shared_ptr<FastTopic>> topics_;
     std::unordered_map<uint16_t, std::shared_ptr<FastPublisher>> publishers_;

--- a/src/cpp/middleware/fast/FastEntities.cpp
+++ b/src/cpp/middleware/fast/FastEntities.cpp
@@ -214,10 +214,10 @@ bool FastTopic::match(const fastrtps::TopicAttributes& attrs) const
 FastDataWriter::FastDataWriter(
         fastrtps::Publisher* impl,
         const std::shared_ptr<FastTopic>& topic,
-        const std::shared_ptr<FastParticipant>& participant)
+        const std::shared_ptr<FastPublisher>& publisher)
     : impl_{impl}
     , topic_{topic}
-    , participant_{participant}
+    , publisher_{publisher}
 {}
 
 FastDataWriter::~FastDataWriter()
@@ -243,10 +243,10 @@ bool FastDataWriter::write(
 FastDataReader::FastDataReader(
         fastrtps::Subscriber* impl,
         const std::shared_ptr<FastTopic>& topic,
-        const std::shared_ptr<FastParticipant>& participant)
+        const std::shared_ptr<FastSubscriber>& subscriber)
     : impl_{impl}
     , topic_{topic}
-    , participant_{participant}
+    , subscriber_{subscriber}
 {}
 
 FastDataReader::~FastDataReader()

--- a/src/cpp/middleware/fast/FastEntities.cpp
+++ b/src/cpp/middleware/fast/FastEntities.cpp
@@ -29,6 +29,76 @@ namespace eprosima {
 namespace uxr {
 
 /**********************************************************************************************************************
+ * FastListener
+ **********************************************************************************************************************/
+void FastListener::onParticipantDiscovery(
+        fastrtps::Participant*,
+        fastrtps::rtps::ParticipantDiscoveryInfo&& info)
+{
+    if (info.status == eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT)
+    {
+        UXR_AGENT_LOG_TRACE(
+            UXR_DECORATE_WHITE("matched"),
+            "entity_id: {}, guid_prefix: {}",
+            info.info.m_guid.entityId,
+            info.info.m_guid.guidPrefix);
+    }
+    else
+    {
+        UXR_AGENT_LOG_TRACE(
+            UXR_DECORATE_WHITE("unmatched"),
+            "entity_id: {}, guid_prefix: {}",
+            info.info.m_guid.entityId,
+            info.info.m_guid.guidPrefix);
+    }
+}
+
+void FastListener::onPublicationMatched(
+        fastrtps::Publisher*,
+        fastrtps::rtps::MatchingInfo& info)
+{
+    if (info.status == fastrtps::rtps::MATCHED_MATCHING)
+    {
+        UXR_AGENT_LOG_TRACE(
+            UXR_DECORATE_WHITE("matched"),
+            "entity_id: {}, guid_prefix: {}",
+            info.remoteEndpointGuid.entityId,
+            info.remoteEndpointGuid.guidPrefix);
+    }
+    else
+    {
+        UXR_AGENT_LOG_TRACE(
+            UXR_DECORATE_WHITE("unmatched"),
+            "entity_id: {}, guid_prefix: {}",
+            info.remoteEndpointGuid.entityId,
+            info.remoteEndpointGuid.guidPrefix);
+    }
+}
+
+void FastListener::onSubscriptionMatched(
+        fastrtps::Subscriber*,
+        fastrtps::rtps::MatchingInfo& info)
+{
+    if (info.status == fastrtps::rtps::MATCHED_MATCHING)
+    {
+        UXR_AGENT_LOG_TRACE(
+            UXR_DECORATE_WHITE("matched"),
+            "entity_id: {}, guid_prefix: {}",
+            info.remoteEndpointGuid.entityId,
+            info.remoteEndpointGuid.guidPrefix);
+    }
+    else
+    {
+        UXR_AGENT_LOG_TRACE(
+            UXR_DECORATE_WHITE("unmatched"),
+            "entity_id: {}, guid_prefix: {}",
+            info.remoteEndpointGuid.entityId,
+            info.remoteEndpointGuid.guidPrefix);
+    }
+}
+
+
+/**********************************************************************************************************************
  * FastParticipant
  **********************************************************************************************************************/
 FastParticipant::~FastParticipant()


### PR DESCRIPTION
This PR refactors FastEntities
* Creating a common `FastListener` using as the listener in `FastParticipant`, `FastDataWriter`, `FastDataReader`, `FastRequester` and `FastReplier`.
* Modifying the hierarchy where `FastDataWriter` and `FastDataReader` contains a reference to `FastPublisher` and `FastSubscriber` instead to `FastParticipant`.