### PR TITLE
Default isolated install and FastDDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ endif()
 ###############################################################################
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 if(NOT UAGENT_SUPERBUILD)
-    project(microxrcedds_agent VERSION "1.4.0" LANGUAGES C CXX)
+    project(microxrcedds_agent VERSION "1.4.1" LANGUAGES C CXX)
 else()
     project(uagent_superbuild NONE)
     include(${PROJECT_SOURCE_DIR}/cmake/SuperBuild.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 option(UAGENT_SUPERBUILD "Enable superbuild compilation." ON)
 option(UAGENT_BUILD_TESTS "Build tests." OFF)
 option(UAGENT_INSTALLER "Build Windows installer." OFF)
-option(UAGENT_ISOLATED_INSTALL "Install the project and dependencies into saparated folders with version control." ON)
+option(UAGENT_ISOLATED_INSTALL "Install the project and dependencies into saparated folders with version control." OFF)
 option(UAGENT_USE_INTERNAL_GTEST "Enable internal GTest libraries." OFF)
 option(BUILD_SHARED_LIBS "Control shared/static building." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(UAGENT_P2P_PROFILE)
 endif()
 
 if(UAGENT_FAST_PROFILE)
-    set(_fastdds_version 2.0.0)
+    set(_fastdds_version 2.0)
     set(_fastdds_tag 2.0.x)
     list(APPEND _deps "fastrtps\;${_fastdds_version}")
     set(_foonathan_memory_tag master)
@@ -124,7 +124,7 @@ set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_BINARY_DIR}/temp_install)
 foreach(d ${_deps})
     list(GET d 0 _name)
     list(GET d 1 _version)
-    find_package(${_name} ${_version} EXACT REQUIRED)
+    find_package(${_name} ${_version} REQUIRED)
 endforeach()
 
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,9 @@ if(UAGENT_P2P_PROFILE)
 endif()
 
 if(UAGENT_FAST_PROFILE)
-    set(_fastrtps_version 2.0.0)
-    set(_fastrtps_tag e58dcb1)
-    list(APPEND _deps "fastrtps\;${_fastrtps_version}")
+    set(_fastdds_version 2.0.0)
+    set(_fastdds_tag 2.0.x)
+    list(APPEND _deps "fastrtps\;${_fastdds_version}")
     set(_foonathan_memory_tag master)
 endif()
 

--- a/cmake/SuperBuild.cmake
+++ b/cmake/SuperBuild.cmake
@@ -103,7 +103,7 @@ if(UAGENT_FAST_PROFILE)
 
     # Fast DDS.
     unset(fastdds_DIR CACHE)
-    find_package(fastdds ${_fastdds_version} EXACT QUIET)
+    find_package(fastrtps ${_fastdds_version} EXACT QUIET)
     if(NOT fastdds_FOUND)
         ExternalProject_Add(fastdds
             GIT_REPOSITORY

--- a/cmake/SuperBuild.cmake
+++ b/cmake/SuperBuild.cmake
@@ -101,19 +101,19 @@ if(UAGENT_FAST_PROFILE)
             )
     endif()
 
-    # Fast RTPS.
-    unset(fastrtps_DIR CACHE)
-    find_package(fastrtps ${_fastrtps_version} EXACT QUIET)
-    if(NOT fastrtps_FOUND)
-        ExternalProject_Add(fastrtps
+    # Fast DDS.
+    unset(fastdds_DIR CACHE)
+    find_package(fastdds ${_fastdds_version} EXACT QUIET)
+    if(NOT fastdds_FOUND)
+        ExternalProject_Add(fastdds
             GIT_REPOSITORY
-                https://github.com/eProsima/Fast-RTPS.git
+                https://github.com/eProsima/Fast-DDS.git
             GIT_TAG
-                ${_fastrtps_tag}
+                ${_fastdds_tag}
             PREFIX
-                ${PROJECT_BINARY_DIR}/fastrtps
+                ${PROJECT_BINARY_DIR}/fastdds
             INSTALL_DIR
-                ${PROJECT_BINARY_DIR}/temp_install/fastrtps-${_fastrtps_version}
+                ${PROJECT_BINARY_DIR}/temp_install/fastrtps-${_fastdds_version}
             CMAKE_CACHE_ARGS
                 -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
                 -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH};${PROJECT_BINARY_DIR}/temp_install
@@ -134,7 +134,7 @@ if(UAGENT_FAST_PROFILE)
             TEST_COMMAND
                 COMMAND ${CMAKE_COMMAND} -E rename <SOURCE_DIR>/src/cpp/CMakeLists.txt.bak <SOURCE_DIR>/src/cpp/CMakeLists.txt
             )
-        list(APPEND _deps fastrtps)
+        list(APPEND _deps fastdds)
     endif()
 endif()
 

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -26,7 +26,7 @@ set_and_check(@PROJECT_NAME@_DATA_DIR "@PACKAGE_DATA_INSTALL_DIR@")
 foreach(d @_deps@)
     list(GET d 0 _name)
     list(GET d 1 _version)
-    find_package(${_name} ${_version} EXACT REQUIRED)
+    find_package(${_name} ${_version} REQUIRED)
 endforeach()
 
 include(${@PROJECT_NAME@_DATA_DIR}/@PROJECT_NAME@/cmake/@PROJECT_NAME@Targets.cmake)


### PR DESCRIPTION
This PR changes the default `UAGENT_ISOLATED_INSTALL` to OFF to address https://github.com/eProsima/Micro-XRCE-DDS-Agent/issues/166 and changes the naming from FastRTPS to FastDDS.

Integration tests pass here: https://github.com/eProsima/Micro-XRCE-DDS/pull/51#issuecomment-636822136