### PR TITLE
Server buffer size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(UAGENT_CONFIG_TCP_MAX_CONNECTIONS          100      CACHE STRING "Maximum TC
 set(UAGENT_CONFIG_TCP_MAX_BACKLOG_CONNECTIONS  100      CACHE STRING "Maximum TCP backlog connection allowed.")
 set(UAGENT_CONFIG_SERVER_QUEUE_MAX_SIZE        32000    CACHE STRING "Maximum server's queues size.")
 set(UAGENT_CONFIG_CLIENT_DEAD_TIME             30000    CACHE STRING "Client dead time in milliseconds.")
+set(UAGENT_SERVER_BUFFER_SIZE                  65535    CACHE STRING "Server buffer size.")
 
 ###############################################################################
 # Dependencies
@@ -92,7 +93,7 @@ endif()
 ###############################################################################
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 if(NOT UAGENT_SUPERBUILD)
-    project(microxrcedds_agent VERSION "1.4.1" LANGUAGES C CXX)
+    project(microxrcedds_agent VERSION "1.4.2" LANGUAGES C CXX)
 else()
     project(uagent_superbuild NONE)
     include(${PROJECT_SOURCE_DIR}/cmake/SuperBuild.cmake)

--- a/include/uxr/agent/config.hpp.in
+++ b/include/uxr/agent/config.hpp.in
@@ -45,6 +45,8 @@ const uint16_t SERVER_QUEUE_MAX_SIZE = @UAGENT_CONFIG_SERVER_QUEUE_MAX_SIZE@;
 
 constexpr std::chrono::milliseconds CLIENT_DEAD_TIME{@UAGENT_CONFIG_CLIENT_DEAD_TIME@};
 
+const uint16_t SERVER_BUFFER_SIZE = @UAGENT_SERVER_BUFFER_SIZE@;
+
 } // namespace uxr
 } // namespace eprosima
 

--- a/include/uxr/agent/transport/serial/SerialAgentLinux.hpp
+++ b/include/uxr/agent/transport/serial/SerialAgentLinux.hpp
@@ -75,7 +75,7 @@ private:
 protected:
     const uint8_t addr_;
     struct pollfd poll_fd_;
-    uint8_t buffer_[UINT16_MAX];
+    uint8_t buffer_[SERVER_BUFFER_SIZE];
     SerialIO serial_io_;
 };
 

--- a/include/uxr/agent/transport/tcp/TCPv4AgentLinux.hpp
+++ b/include/uxr/agent/transport/tcp/TCPv4AgentLinux.hpp
@@ -116,7 +116,7 @@ private:
     std::mutex connections_mtx_;
     struct pollfd listener_poll_;
     std::array<struct pollfd, TCP_MAX_CONNECTIONS> poll_fds_;
-    uint8_t buffer_[UINT16_MAX];
+    uint8_t buffer_[SERVER_BUFFER_SIZE];
     uint16_t agent_port_;
     std::thread listener_thread_;
     std::atomic<bool> running_cond_;

--- a/include/uxr/agent/transport/tcp/TCPv4AgentWindows.hpp
+++ b/include/uxr/agent/transport/tcp/TCPv4AgentWindows.hpp
@@ -114,7 +114,7 @@ private:
     std::mutex connections_mtx_;
     struct pollfd listener_poll_;
     std::array<struct pollfd, TCP_MAX_CONNECTIONS> poll_fds_;
-    uint8_t buffer_[UINT16_MAX];
+    uint8_t buffer_[SERVER_BUFFER_SIZE];
     uint16_t agent_port_;
     std::thread listener_thread_;
     std::atomic<bool> running_cond_;

--- a/include/uxr/agent/transport/tcp/TCPv6AgentLinux.hpp
+++ b/include/uxr/agent/transport/tcp/TCPv6AgentLinux.hpp
@@ -117,7 +117,7 @@ private:
     std::mutex connections_mtx_;
     struct pollfd listener_poll_;
     std::array<struct pollfd, TCP_MAX_CONNECTIONS> poll_fds_;
-    uint8_t buffer_[UINT16_MAX];
+    uint8_t buffer_[SERVER_BUFFER_SIZE];
     uint16_t agent_port_;
     std::thread listener_thread_;
     std::atomic<bool> running_cond_;

--- a/include/uxr/agent/transport/tcp/TCPv6AgentWindows.hpp
+++ b/include/uxr/agent/transport/tcp/TCPv6AgentWindows.hpp
@@ -115,7 +115,7 @@ private:
     std::mutex connections_mtx_;
     struct pollfd listener_poll_;
     std::array<struct pollfd, TCP_MAX_CONNECTIONS> poll_fds_;
-    uint8_t buffer_[UINT16_MAX];
+    uint8_t buffer_[SERVER_BUFFER_SIZE];
     uint16_t agent_port_;
     std::thread listener_thread_;
     std::atomic<bool> running_cond_;

--- a/include/uxr/agent/transport/udp/UDPv4AgentLinux.hpp
+++ b/include/uxr/agent/transport/udp/UDPv4AgentLinux.hpp
@@ -74,7 +74,7 @@ private:
 
 private:
     struct pollfd poll_fd_;
-    uint8_t buffer_[UINT16_MAX];
+    uint8_t buffer_[SERVER_BUFFER_SIZE];
     uint16_t agent_port_;
 #ifdef UAGENT_DISCOVERY_PROFILE
     DiscoveryServerLinux<IPv4EndPoint> discovery_server_;

--- a/include/uxr/agent/transport/udp/UDPv4AgentWindows.hpp
+++ b/include/uxr/agent/transport/udp/UDPv4AgentWindows.hpp
@@ -70,7 +70,7 @@ private:
 
 private:
     WSAPOLLFD poll_fd_;
-    uint8_t buffer_[UINT16_MAX];
+    uint8_t buffer_[SERVER_BUFFER_SIZE];
     uint16_t agent_port_;
 #ifdef UAGENT_DISCOVERY_PROFILE
     DiscoveryServerWindows<IPv4EndPoint> discovery_server_;

--- a/include/uxr/agent/transport/udp/UDPv6AgentLinux.hpp
+++ b/include/uxr/agent/transport/udp/UDPv6AgentLinux.hpp
@@ -71,7 +71,7 @@ private:
 
 private:
     struct pollfd poll_fd_;
-    uint8_t buffer_[UINT16_MAX];
+    uint8_t buffer_[SERVER_BUFFER_SIZE];
     uint16_t agent_port_;
 #ifdef UAGENT_DISCOVERY_PROFILE
     DiscoveryServerLinux<IPv6EndPoint> discovery_server_;

--- a/include/uxr/agent/transport/udp/UDPv6AgentWindows.hpp
+++ b/include/uxr/agent/transport/udp/UDPv6AgentWindows.hpp
@@ -70,9 +70,8 @@ private:
 
 private:
     WSAPOLLFD poll_fd_;
-    uint8_t buffer_[UINT16_MAX];
+    uint8_t buffer_[SERVER_BUFFER_SIZE];
     uint16_t agent_port_;
-//    dds::xrce::TransportAddress transport_address_;
 #ifdef UAGENT_DISCOVERY_PROFILE
     DiscoveryServerWindows<IPv6EndPoint> discovery_server_;
 #endif


### PR DESCRIPTION
This PR adds a CMake flag which allows setting the server buffer size in order to optimize the memory profiling for particular applications.