### PR TITLE
Refs #8722. Option to disable CLI; add custom argparser [#8856]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ if(UAGENT_FAST_PROFILE)
     set(_fastdds_version 2.0)
     set(_fastdds_tag 2.0.x)
     list(APPEND _deps "fastrtps\;${_fastdds_version}")
+    set(_foonathan_memory_tag c619113) # This tag should be updated every time it gets updated in foonathan_memory_vendor eProsima's package
 endif()
 
 if(UAGENT_LOGGER_PROFILE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ option(UAGENT_DISCOVERY_PROFILE "Build Discovery profile." ON)
 option(UAGENT_P2P_PROFILE "Build P2P discovery profile." ON)
 option(UAGENT_LOGGER_PROFILE "Build logger profile." ON)
 option(UAGENT_SECURITY_PROFILE "Build security profile." OFF)
+option(UAGENT_CLI_PROFILE "Build CLI profile." ON)
 
 option(UAGENT_BUILD_CI_TESTS "Build CI test cases.")
 if(UAGENT_BUILD_CI_TESTS)
@@ -65,9 +66,11 @@ set(_fastcdr_version 1.0.13)
 set(_fastcdr_tag v1.0.13)
 list(APPEND _deps "fastcdr\;${_fastcdr_version}")
 
-set(_cli11_version 1.7.1)
-set(_cli11_tag v1.7.1)
-list(APPEND _deps "CLI11\;${_cli11_version}")
+if(UAGENT_CLI_PROFILE)
+    set(_cli11_version 1.7.1)
+    set(_cli11_tag v1.7.1)
+    list(APPEND _deps "CLI11\;${_cli11_version}")
+endif()
 
 if(UAGENT_P2P_PROFILE)
     set(_microxrcedds_client_version 1.2.3)
@@ -278,7 +281,7 @@ target_link_libraries(${PROJECT_NAME}
         $<$<PLATFORM_ID:Windows>:ws2_32>
         $<$<PLATFORM_ID:Windows>:iphlpapi>
         $<$<BOOL:${UAGENT_LOGGER_PROFILE}>:spdlog::spdlog>
-        CLI11::CLI11
+        $<$<BOOL:${UAGENT_CLI_PROFILE}>:CLI11::CLI11>
     PRIVATE
         $<$<BOOL:${UAGENT_FAST_PROFILE}>:fastrtps>
         $<$<BOOL:${UAGENT_P2P_PROFILE}>:microxrcedds_client>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,6 @@ if(UAGENT_FAST_PROFILE)
     set(_fastdds_version 2.0)
     set(_fastdds_tag 2.0.x)
     list(APPEND _deps "fastrtps\;${_fastdds_version}")
-    set(_foonathan_memory_tag master)
 endif()
 
 if(UAGENT_LOGGER_PROFILE)

--- a/cmake/SuperBuild.cmake
+++ b/cmake/SuperBuild.cmake
@@ -139,30 +139,33 @@ if(UAGENT_FAST_PROFILE)
 endif()
 
 # CLI11.
-unset(CLI11_DIR CACHE)
-find_package(CLI11 ${_cli11_version} EXACT QUIET)
-if(NOT CLI11_FOUND)
-    ExternalProject_Add(cli11
-        GIT_REPOSITORY
-            https://github.com/CLIUtils/CLI11.git
-        GIT_TAG
-            ${_cli11_tag}
-        PREFIX
-            ${PROJECT_BINARY_DIR}/CLI11
-        INSTALL_DIR
-            ${PROJECT_BINARY_DIR}/temp_install/cli11-${_cli11_version}
-        CMAKE_CACHE_ARGS
-            -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-            -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH};${CMAKE_INSTALL_PREFIX}
-            -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
-            -DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}
-            -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-            -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
-            -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
-            -DCLI11_TESTING:BOOL=OFF
-            -DCLI11_EXAMPLES:BOOL=OFF
-        )
-    list(APPEND _deps cli11)
+if(UAGENT_CLI_PROFILE)
+    message(WARNING "           SUPERBUILD UAGENT_CLI_PROFILE ON")
+    unset(CLI11_DIR CACHE)
+    find_package(CLI11 ${_cli11_version} EXACT QUIET)
+    if(NOT CLI11_FOUND)
+        ExternalProject_Add(cli11
+            GIT_REPOSITORY
+                https://github.com/CLIUtils/CLI11.git
+            GIT_TAG
+                ${_cli11_tag}
+            PREFIX
+                ${PROJECT_BINARY_DIR}/CLI11
+            INSTALL_DIR
+                ${PROJECT_BINARY_DIR}/temp_install/cli11-${_cli11_version}
+            CMAKE_CACHE_ARGS
+                -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+                -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH};${CMAKE_INSTALL_PREFIX}
+                -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
+                -DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}
+                -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+                -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+                -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+                -DCLI11_TESTING:BOOL=OFF
+                -DCLI11_EXAMPLES:BOOL=OFF
+            )
+        list(APPEND _deps cli11)
+    endif()
 endif()
 
 if(UAGENT_LOGGER_PROFILE)

--- a/cmake/SuperBuild.cmake
+++ b/cmake/SuperBuild.cmake
@@ -84,9 +84,7 @@ if(UAGENT_FAST_PROFILE)
     if (NOT foonathan_memory_FOUND)
         ExternalProject_Add(foonathan_memory
             GIT_REPOSITORY
-                https://github.com/foonathan/memory.git
-            GIT_TAG
-                ${_foonathan_memory_tag}
+                https://github.com/eProsima/foonathan_memory_vendor.git
             PREFIX
                 ${PROJECT_BINARY_DIR}/foonathan_memory
             INSTALL_DIR

--- a/cmake/SuperBuild.cmake
+++ b/cmake/SuperBuild.cmake
@@ -84,7 +84,9 @@ if(UAGENT_FAST_PROFILE)
     if (NOT foonathan_memory_FOUND)
         ExternalProject_Add(foonathan_memory
             GIT_REPOSITORY
-                https://github.com/eProsima/foonathan_memory_vendor.git
+                https://github.com/foonathan/memory.git
+            GIT_TAG
+                ${_foonathan_memory_tag}
             PREFIX
                 ${PROJECT_BINARY_DIR}/foonathan_memory
             INSTALL_DIR

--- a/cmake/SuperBuild.cmake
+++ b/cmake/SuperBuild.cmake
@@ -140,7 +140,6 @@ endif()
 
 # CLI11.
 if(UAGENT_CLI_PROFILE)
-    message(WARNING "           SUPERBUILD UAGENT_CLI_PROFILE ON")
     unset(CLI11_DIR CACHE)
     find_package(CLI11 ${_cli11_version} EXACT QUIET)
     if(NOT CLI11_FOUND)

--- a/include/uxr/agent/config.hpp.in
+++ b/include/uxr/agent/config.hpp.in
@@ -28,6 +28,7 @@ namespace uxr {
 #cmakedefine UAGENT_P2P_PROFILE
 #endif
 #cmakedefine UAGENT_LOGGER_PROFILE
+#cmakedefine UAGENT_CLI_PROFILE
 
 const uint16_t DISCOVERY_PORT = 7400;
 const char* const DISCOVERY_IP = "239.255.0.2";

--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -1,0 +1,970 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UXR_AGENT_UTILS_ARGUMENTPARSER_HPP_
+#define UXR_AGENT_UTILS_ARGUMENTPARSER_HPP_
+
+#include <csignal>
+#include <type_traits>
+#include <unordered_map>
+#include <uxr/agent/transport/Server.hpp>
+
+#ifdef _WIN32
+#include <uxr/agent/transport/udp/UDPv4AgentWindows.hpp>
+#include <uxr/agent/transport/udp/UDPv6AgentWindows.hpp>
+#include <uxr/agent/transport/tcp/TCPv4AgentWindows.hpp>
+#include <uxr/agent/transport/tcp/TCPv6AgentWindows.hpp>
+#else
+#include <uxr/agent/transport/udp/UDPv4AgentLinux.hpp>
+#include <uxr/agent/transport/udp/UDPv6AgentLinux.hpp>
+#include <uxr/agent/transport/tcp/TCPv4AgentLinux.hpp>
+#include <uxr/agent/transport/tcp/TCPv6AgentLinux.hpp>
+#include <uxr/agent/transport/serial/TermiosAgentLinux.hpp>
+#include <uxr/agent/transport/serial/PseudoTerminalAgentLinux.hpp>
+#include <uxr/agent/transport/serial/baud_rate_table_linux.h>
+
+#include <termios.h>
+#include <fcntl.h>
+#endif // _WIN32
+
+#define DEFAULT_MIDDLEWARE      "dds"
+#define DEFAULT_VERBOSE_LEVEL   4
+#define DEFAULT_DISCOVERY_PORT  7400
+#define DEFAULT_BAUDRATE_LEVEL  "115200"
+
+namespace eprosima {
+namespace uxr {
+namespace agent {
+
+enum class TransportKind
+{
+    INVALID,
+    UDP4,
+    UDP6,
+    TCP4,
+    TCP6,
+#ifndef _WIN32
+    SERIAL,
+    PSEUDOTERMINAL,
+#endif // _WIN32
+};
+
+template <typename AgentKind>
+std::thread create_agent_thread(
+        int argc,
+        char** argv,
+        TransportKind transport_kind,
+        const sigset_t* signals);
+
+namespace parser {
+namespace utils {
+
+bool usage(
+        bool no_help = true);
+
+TransportKind check_transport(
+        const char* transport);
+
+Middleware::Kind get_mw_kind(
+        const std::string& kind);
+} // namespace utils
+
+using dummy_type = bool;
+
+enum class ArgumentKind
+{
+    NO_VALUE,
+    VALUE,
+};
+
+enum class ParseResult
+{
+    INVALID,
+    NOT_FOUND,
+    VALID,
+    HELP,
+};
+
+/*************************************************************************************************
+ * Generic command line argument representation
+ *************************************************************************************************/
+template <typename T>
+class Argument
+{
+public:
+    Argument(
+            const char* short_alias,
+            const char* long_alias,
+            ArgumentKind kind = ArgumentKind::VALUE,
+            const std::set<T> allowed_values = {})
+        : argument_kind_(kind)
+        , short_alias_(short_alias)
+        , long_alias_(long_alias)
+        , value_()
+        , parse_found_(false)
+        , allowed_values_(allowed_values)
+    {
+    }
+
+    Argument(
+            const char* short_alias,
+            const char* long_alias,
+            const T& default_value,
+            const std::set<T> allowed_values = {})
+        : argument_kind_(ArgumentKind::VALUE)
+        , short_alias_(short_alias)
+        , long_alias_(long_alias)
+        , value_(default_value)
+        , parse_found_(false)
+        , allowed_values_(allowed_values)
+    {
+    }
+
+    const T& value() const
+    {
+        return value_;
+    }
+
+    bool found()
+    {
+        return parse_found_;
+    }
+
+    ParseResult parse_argument(
+            int argc,
+            char** argv)
+    {
+        for (size_t position = 0; position < argc; ++position)
+        {
+            if (0 == strcmp(argv[position], short_alias_.c_str()) ||
+                0 == strcmp(argv[position], long_alias_.c_str()))
+            {
+                if (ArgumentKind::VALUE == argument_kind_)
+                {
+                    if (argc > (++position))
+                    {
+                        std::string value_str(argv[position]);
+                        if (true == std::is_integral<T>::value)
+                        {
+                            if (std::all_of(value_str.begin(), value_str.end(), ::isdigit))
+                            {
+                                value_ = static_cast<T>(stol(value_str));
+                                if (!allowed_values_.empty() &&
+                                    allowed_values_.find(value_) == allowed_values_.end())
+                                {
+                                    std::stringstream ss;
+                                    ss << "Warning: introduced value for argument '" << long_alias_;
+                                    ss << "' is not allowed. Please choose between { ";
+                                    for (const auto& allowed_value_ : allowed_values_)
+                                    {
+                                        ss << allowed_value_ << ((*allowed_values_.rbegin() != allowed_value_) ? ", " : " }.");
+                                    }
+                                    ss << std::endl;
+                                    std::cerr << ss.str();
+                                    return ParseResult::INVALID;
+                                }
+                                parse_found_ = true;
+                                return ParseResult::VALID;
+                            }
+                            else
+                            {
+                                return ParseResult::INVALID;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        return ParseResult::INVALID;
+                    }
+                }
+                else
+                {
+                    parse_found_ = true;
+                    return ParseResult::VALID;
+                }
+            }
+        }
+        return ParseResult::NOT_FOUND;
+    }
+
+    const std::string get_help() const
+    {
+        std::stringstream ss;
+        ss << short_alias_ << "/" << long_alias_;
+        if (ArgumentKind::VALUE == argument_kind_)
+        {
+            ss << " <value>";
+        }
+        if (!allowed_values_.empty())
+        {
+            ss << " (";
+            for (const auto& allowed_value_ : allowed_values_)
+            {
+                ss << allowed_value_ << ((*allowed_values_.rbegin() != allowed_value_) ? ", " : " )");
+            }
+        }
+        ss << ".";
+        return ss.str();
+    }
+
+private:
+    ArgumentKind argument_kind_;
+    T value_;
+    std::string short_alias_;
+    std::string long_alias_;
+    bool parse_found_;
+    std::set<T> allowed_values_;
+};
+
+/*************************************************************************************************
+ * Specialized command line argument representation for std::string
+ *************************************************************************************************/
+template <>
+class Argument<std::string>
+{
+public:
+    Argument(
+            const char* short_alias,
+            const char* long_alias,
+            const std::set<std::string> allowed_values = {},
+            ArgumentKind kind = ArgumentKind::VALUE)
+        : argument_kind_(kind)
+        , short_alias_(short_alias)
+        , long_alias_(long_alias)
+        , value_()
+        , parse_found_(false)
+        , allowed_values_(allowed_values)
+    {
+    }
+
+    Argument(
+            const char* short_alias,
+            const char* long_alias,
+            const std::string& default_value,
+            const std::set<std::string> allowed_values = {})
+        : argument_kind_(ArgumentKind::VALUE)
+        , short_alias_(short_alias)
+        , long_alias_(long_alias)
+        , value_(default_value)
+        , parse_found_(false)
+        , allowed_values_(allowed_values)
+    {
+    }
+
+    const std::string& value() const
+    {
+        return value_;
+    }
+
+    bool found()
+    {
+        return parse_found_;
+    }
+
+ParseResult parse_argument(
+            int argc,
+            char** argv)
+    {
+        for (size_t position = 0; position < argc; ++position)
+        {
+            if (0 == strcmp(argv[position], short_alias_.c_str()) ||
+                0 == strcmp(argv[position], long_alias_.c_str()))
+            {
+                if (ArgumentKind::VALUE == argument_kind_)
+                {
+                    if (argc > (++position))
+                    {
+                        value_ = std::string(argv[position]);
+                        if (!allowed_values_.empty() &&
+                            allowed_values_.find(value_) == allowed_values_.end())
+                        {
+                            std::stringstream ss;
+                            ss << "Warning: introduced value for argument '" << long_alias_;
+                            ss << "' is not allowed. Please choose between { ";
+                            for (const auto& allowed_value_ : allowed_values_)
+                            {
+                                ss << allowed_value_ << ((*allowed_values_.rbegin() != allowed_value_) ? ", " : " }.");
+                            }
+                            ss << std::endl;
+                            std::cerr << ss.str();
+                            return ParseResult::INVALID;
+                        }
+                        parse_found_ = true;
+                        return ParseResult::VALID;
+                    }
+                    else
+                    {
+                        return ParseResult::INVALID;
+                    }
+                }
+                else
+                {
+                    parse_found_ = true;
+                    return ParseResult::VALID;
+                }
+            }
+        }
+        return ParseResult::NOT_FOUND;
+    }
+
+    const std::string get_help() const
+    {
+        std::stringstream ss;
+        ss << short_alias_ << "/" << long_alias_;
+        if (ArgumentKind::VALUE == argument_kind_)
+        {
+            ss << " <value>";
+        }
+        if (!allowed_values_.empty())
+        {
+            ss << " ( ";
+            for (const auto& allowed_value_ : allowed_values_)
+            {
+                ss << allowed_value_ << ((*allowed_values_.rbegin() != allowed_value_) ? ", " : " )");
+            }
+        }
+        ss << ".";
+        return ss.str();
+    }
+
+private:
+    ArgumentKind argument_kind_;
+    std::string value_;
+    std::string short_alias_;
+    std::string long_alias_;
+    bool parse_found_;
+    std::set<std::string> allowed_values_;
+};
+
+/*************************************************************************************************
+ * Common arguments for each available transport
+ *************************************************************************************************/
+template <typename AgentType>
+class CommonArgs
+{
+public:
+    CommonArgs()
+        : help_("-h", "--help", ArgumentKind::NO_VALUE)
+        , middleware_("-m", "--middleware", std::string(DEFAULT_MIDDLEWARE),
+            {"dds", "ced", "rtps"})
+        , refs_("-r", "--refs")
+        , verbose_("-v", "--verbose", static_cast<uint16_t>(DEFAULT_VERBOSE_LEVEL),
+            {0, 1, 2, 3, 4, 5, 6})
+#ifdef UAGENT_DISCOVERY_PROFILE
+        , discovery_("-d", "--discovery", static_cast<uint16_t>(DEFAULT_DISCOVERY_PORT))
+#endif
+#ifdef UAGENT_P2P_PROFILE
+        , p2p_("-P", "--p2p")
+#endif
+    {
+    }
+
+    const std::string middleware() const
+    {
+        return middleware_.value();
+    }
+
+    std::pair<bool, bool> parse(
+            int argc,
+            char** argv)
+    {
+        std::pair<bool, bool> result(true, false);
+        ParseResult parse_help = help_.parse_argument(argc, argv);
+        if (ParseResult::VALID == parse_help)
+        {
+            result.first = true;
+            result.second = true;
+            return result;
+        }
+        result.first &= static_cast<bool>(middleware_.parse_argument(argc, argv));
+        ParseResult refs_arg = refs_.parse_argument(argc, argv);
+        if (ParseResult::VALID == refs_arg)
+        {
+            struct stat sb;
+            if (stat(refs_.value().c_str(), &sb) < 0)
+            {
+                std::cerr << "Error: reference file '" << refs_.value() << "' does not exist!" << std::endl;
+                result.first = false;
+                return result;
+            }
+        }
+        result.first &= static_cast<bool>(refs_arg);
+        result.first &= static_cast<bool>(verbose_.parse_argument(argc, argv));
+#ifdef UAGENT_DISCOVERY_PROFILE
+        result.first &= static_cast<bool>(discovery_.parse_argument(argc, argv));
+#endif
+#ifdef UAGENT_P2P_PROFILE
+        result.first &= static_cast<bool>(p2p_.parse_argument(argc, argv));
+#endif
+        return result;
+    }
+
+    void apply_actions(
+            std::unique_ptr<AgentType>& server)
+    {
+#ifdef UAGENT_DISCOVERY_PROFILE
+        if (discovery_.found())
+        {
+            server->enable_discovery(discovery_.value());
+        }
+#endif
+#ifdef UAGENT_P2P_PROFILE
+        if (p2p_.found())
+        {
+            server->enable_p2p(p2p_.value());
+        }
+#endif
+        if (refs_.found())
+        {
+            server->load_config_file(refs_.value());
+        }
+        if (verbose_.found())
+        {
+            server->set_verbose_level(verbose_.value());
+        }
+    }
+
+    const std::string get_help() const
+    {
+        std::stringstream ss;
+        ss << "    " << help_.get_help() << std::endl;
+        ss << "    " << middleware_.get_help() << std::endl;
+        ss << "    " << refs_.get_help() << std::endl;
+        ss << "    " << verbose_.get_help() << std::endl;
+#ifdef UAGENT_DISCOVERY_PROFILE
+        ss << "    " << discovery_.get_help() << std::endl;
+#endif
+#ifdef UAGENT_P2P_PROFILE
+        ss << "    " << p2p_.get_help() << std::endl;
+#endif
+        return ss.str();
+    }
+
+private:
+    Argument<dummy_type> help_;
+    Argument<std::string> middleware_;
+    Argument<std::string> refs_;
+    Argument<uint16_t> verbose_;
+#ifdef UAGENT_DISCOVERY_PROFILE
+    Argument<uint16_t> discovery_;
+#endif
+#ifdef UAGENT_P2P_PROFILE
+    Argument<uint16_t> p2p_;
+#endif
+};
+
+/*************************************************************************************************
+ * Specific arguments for IPvX transports
+ *************************************************************************************************/
+template <typename AgentType>
+class IPvXArgs
+{
+public:
+    IPvXArgs()
+        : port_("-p", "--port")
+    {
+    }
+
+    bool parse(
+            int argc,
+            char** argv)
+    {
+        ParseResult parse_port = port_.parse_argument(argc, argv);
+        if (ParseResult::VALID != parse_port)
+        {
+            std::cerr << "Warning: '--port <value>' is required" << std::endl;
+        }
+        return (ParseResult::VALID == parse_port ? true : false);
+    }
+
+    uint16_t port() const
+    {
+        return port_.value();
+    }
+
+    const std::string get_help() const
+    {
+        std::stringstream ss;
+        ss << "    " << port_.get_help() << std::endl;
+        return ss.str();
+    }
+
+private:
+    Argument<uint16_t> port_;
+};
+
+#ifndef _WIN32
+/*************************************************************************************************
+ * Specific arguments for pseudoterminal transports
+ *************************************************************************************************/
+template <typename AgentType>
+class PseudoTerminalArgs
+{
+public:
+    PseudoTerminalArgs()
+        : baudrate_("-b", "--baudrate", DEFAULT_BAUDRATE_LEVEL)
+    {
+    }
+
+    bool parse(
+            int argc,
+            char** argv)
+    {
+        bool result = static_cast<bool>(baudrate_.parse_argument(argc, argv));
+        return result;
+    }
+
+    const std::string baud_rate() const
+    {
+        return baudrate_.value();
+    }
+
+    const std::string get_help() const
+    {
+        std::stringstream ss;
+        ss << "    " << baudrate_.get_help() << std::endl;
+        return ss.str();
+    }
+
+protected:
+    Argument<std::string> baudrate_;
+};
+
+/*************************************************************************************************
+ * Specific arguments for serial termios transports
+ *************************************************************************************************/
+template <typename AgentType>
+class SerialArgs : public PseudoTerminalArgs<AgentType>
+{
+public:
+    SerialArgs()
+        : PseudoTerminalArgs<AgentType>()
+        , dev_("-D", "--dev")
+    {
+    }
+
+    bool parse(
+            int argc,
+            char** argv)
+    {
+        bool result = PseudoTerminalArgs<AgentType>::parse(argc, argv);
+        ParseResult parse_dev = dev_.parse_argument(argc, argv);
+        if (ParseResult::VALID != parse_dev)
+        {
+            std::cerr << "Warning: '--dev <value>' is required" << std::endl;
+        }
+        return (ParseResult::VALID == parse_dev ? true : false);
+    }
+
+    const std::string dev() const
+    {
+        return dev_.value();
+    }
+
+    const std::string get_help() const
+    {
+        std::stringstream ss;
+        ss << "    " << dev_.get_help();
+        ss << " (only available with 'serial' transport)" << std::endl;
+        return ss.str();
+    }
+
+private:
+    Argument<std::string> dev_;
+};
+#endif // _WIN32
+
+/*************************************************************************************************
+ * Main argument parser class
+ *************************************************************************************************/
+template <typename AgentType>
+class ArgumentParser
+{
+public:
+    ArgumentParser(
+            int argc,
+            char** argv,
+            TransportKind transport_kind)
+        : argc_(argc)
+        , argv_(argv)
+        , common_args_()
+        , ip_args_()
+#ifndef _WIN32
+        , serial_args_()
+        , pseudoterminal_args_()
+#endif // _WIN32
+        , transport_kind_(transport_kind)
+        , agent_server_()
+    {
+    }
+
+    ParseResult parse_arguments()
+    {
+        if (2 > argc_)
+        {
+            return ParseResult::INVALID;
+        }
+        std::pair<bool, bool> common_result = common_args_.parse(argc_, argv_);
+        if (common_result.second)
+        {
+            return ParseResult::HELP;
+        }
+
+        bool result = common_result.first;
+        switch (transport_kind_)
+        {
+            case TransportKind::UDP4:
+            case TransportKind::UDP6:
+            case TransportKind::TCP4:
+            case TransportKind::TCP6:
+            {
+                result &= ip_args_.parse(argc_, argv_);
+                break;
+            }
+#ifndef _WIN32
+            case TransportKind::SERIAL:
+            {
+                result &= serial_args_.parse(argc_, argv_);
+                break;
+            }
+            case TransportKind::PSEUDOTERMINAL:
+            {
+                result &= pseudoterminal_args_.parse(argc_, argv_);
+                break;
+            }
+#endif // _WIN32
+        }
+        return (result ? ParseResult::VALID : ParseResult::INVALID);
+    }
+
+    bool launch_ipvx_agent()
+    {
+        agent_server_.reset(new AgentType(ip_args_.port(), utils::get_mw_kind(common_args_.middleware())));
+        if (agent_server_->start())
+        {
+            common_args_.apply_actions(agent_server_);
+            return true;
+        }
+        else
+        {
+            std::cerr << "Error while starting IPvX agent!" << std::endl;
+            return false;
+        }
+    }
+
+#ifndef _WIN32
+    bool launch_termios_agent()
+    {
+        struct termios attr;
+
+        /* Setting CONTROL OPTIONS. */
+        attr.c_cflag |= unsigned(CREAD);    // Enable read.
+        attr.c_cflag |= unsigned(CLOCAL);   // Set local mode.
+        attr.c_cflag &= unsigned(~PARENB);  // Disable parity.
+        attr.c_cflag &= unsigned(~CSTOPB);  // Set one stop bit.
+        attr.c_cflag &= unsigned(~CSIZE);   // Mask the character size bits.
+        attr.c_cflag |= unsigned(CS8);      // Set 8 data bits.
+        attr.c_cflag &= unsigned(~CRTSCTS); // Disable hardware flow control.
+
+        /* Setting LOCAL OPTIONS. */
+        attr.c_lflag &= unsigned(~ICANON);  // Set non-canonical input.
+        attr.c_lflag &= unsigned(~ECHO);    // Disable echoing of input characters.
+        attr.c_lflag &= unsigned(~ECHOE);   // Disable echoing the erase character.
+        attr.c_lflag &= unsigned(~ISIG);    // Disable SIGINTR, SIGSUSP, SIGDSUSP and SIGQUIT signals.
+
+        /* Setting INPUT OPTIONS. */
+        attr.c_iflag &= unsigned(~IXON);    // Disable output software flow control.
+        attr.c_iflag &= unsigned(~IXOFF);   // Disable input software flow control.
+        attr.c_iflag &= unsigned(~INPCK);   // Disable parity check.
+        attr.c_iflag &= unsigned(~ISTRIP);  // Disable strip parity bits.
+        attr.c_iflag &= unsigned(~IGNBRK);  // No ignore break condition.
+        attr.c_iflag &= unsigned(~IGNCR);   // No ignore carrier return.
+        attr.c_iflag &= unsigned(~INLCR);   // No map NL to CR.
+        attr.c_iflag &= unsigned(~ICRNL);   // No map CR to NL.
+
+        /* Setting OUTPUT OPTIONS. */
+        attr.c_oflag &= unsigned(~OPOST);   // Set raw output.
+
+        /* Setting OUTPUT CHARACTERS. */
+        attr.c_cc[VMIN] = 10;
+        attr.c_cc[VTIME] = 1;
+
+        /* Setting baudrate. */
+        speed_t baudrate = getBaudRate(serial_args_.baud_rate().c_str());
+        attr.c_ispeed = baudrate;
+        attr.c_ospeed = baudrate;
+        agent_server_.reset(new TermiosAgent(
+            serial_args_.dev().c_str(),  O_RDWR | O_NOCTTY, attr, 0, utils::get_mw_kind(common_args_.middleware())));
+
+        if (agent_server_->start())
+        {
+            common_args_.apply_actions(agent_server_);
+            return true;
+        }
+        else
+        {
+            std::cerr << "Error while starting serial agent!" << std::endl;
+            return false;
+        }
+    }
+
+    bool launch_pseudoterminal_agent()
+    {
+        agent_server_.reset(new PseudoTerminalAgent(
+            O_RDWR | O_NOCTTY, pseudoterminal_args_.baud_rate().c_str(), 0, utils::get_mw_kind(common_args_.middleware())));
+        if (agent_server_->start())
+        {
+            common_args_.apply_actions(agent_server_);
+            return true;
+        }
+        else
+        {
+            std::cerr << "Error while starting pseudoterminal agent!" << std::endl;
+            return false;
+        }
+    }
+#endif // _WIN32
+
+    void show_help()
+    {
+        utils::usage(false);
+        std::stringstream ss;
+        ss << std::endl << "Available arguments (per transport):" << std::endl;
+        ss << "  * COMMON" << std::endl;
+        ss << common_args_.get_help();
+        ss << "  * IPvX (udp4, udp6, tcp4, tcp6)" << std::endl;
+        ss << ip_args_.get_help();
+        ss << "  * SERIAL" << std::endl;
+        ss << pseudoterminal_args_.get_help();
+        ss << serial_args_.get_help();
+        std::cout << ss.str();
+    }
+
+private:
+    int argc_;
+    char** argv_;
+    CommonArgs<AgentType> common_args_;
+    IPvXArgs<AgentType> ip_args_;
+#ifndef _WIN32
+    SerialArgs<AgentType> serial_args_;
+    PseudoTerminalArgs<AgentType> pseudoterminal_args_;
+#endif // _WIN32
+    TransportKind transport_kind_;
+    std::unique_ptr<AgentType> agent_server_;
+};
+
+namespace utils
+{
+
+bool usage(
+        bool no_help)
+{
+    std::stringstream ss;
+    ss << "Usage: 'MicroXRCEAgent <udp4|udp6|tcp4|tpc6";
+#ifndef _WIN32
+    ss << "|serial|pseudoterminal";
+#endif // _WIN32
+    ss << "> <<args>>'" << std::endl;
+    if (no_help)
+    {
+        ss << "For a more detailed description about all the available arguments, ";
+        ss << "please execute the agent with '-h/--help' option." << std::endl;
+    }
+    std::cout << ss.str();
+    return false;
+}
+
+TransportKind check_transport(
+        const std::string& transport)
+{
+    const std::unordered_map<std::string, TransportKind> valid_transports = {
+    {"udp4", TransportKind::UDP4},
+    {"udp6", TransportKind::UDP6},
+    {"tcp4", TransportKind::TCP4},
+    {"tcp6", TransportKind::TCP6},
+#ifndef _WIN32
+    {"serial", TransportKind::SERIAL},
+    {"pseudoterminal", TransportKind::PSEUDOTERMINAL},
+#endif // _WIN32
+    };
+
+    if (valid_transports.find(transport) != valid_transports.end())
+    {
+        return valid_transports.at(transport);
+    }
+    return TransportKind::INVALID;
+}
+
+Middleware::Kind get_mw_kind(
+        const std::string& kind)
+{
+#ifdef UAGENT_FAST_PROFILE
+    if ("dds" == kind)
+    {
+        return eprosima::uxr::Middleware::Kind::FASTDDS;
+    }
+    if ("rtps" == kind)
+    {
+        return eprosima::uxr::Middleware::Kind::FASTRTPS;
+    }
+#endif
+#ifdef UAGENT_CED_PROFILE
+    if ("ced" == kind)
+    {
+        return eprosima::uxr::Middleware::Kind::CED;
+    }
+#endif
+    return eprosima::uxr::Middleware::Kind::NONE;
+}
+
+} // namespace utils
+} // namespace parser
+
+/*************************************************************************************************
+ * Helper functions to create and launch a microXRCE-DDS agent in a separate thread
+ *************************************************************************************************/
+template <typename AgentKind>
+std::thread create_agent_thread(
+        int argc,
+        char** argv,
+        eprosima::uxr::agent::TransportKind transport_kind,
+        const sigset_t* signals)
+{
+    std::thread agent_thread = std::thread([&]()
+    {
+        eprosima::uxr::agent::parser::ArgumentParser<AgentKind> parser(argc, argv, transport_kind);
+
+        switch (parser.parse_arguments())
+        {
+            case parser::ParseResult::INVALID:
+            {
+                return parser::utils::usage();
+                break;
+            }
+            case parser::ParseResult::VALID:
+            {
+                if (parser.launch_ipvx_agent())
+                {
+#ifdef _WIN32
+                    /* Waiting until exit. */
+                    std::cin.clear();
+                    char exit_flag = 0;
+                    while ('q' != exit_flag)
+                    {
+                        std::cin >> exit_flag;
+                    }
+#else
+                    /* Wait for defined signals. */
+                    int n_signal = 0;
+                    sigwait(signals, &n_signal);
+#endif // _WIN32
+                }
+                break;
+            }
+            case parser::ParseResult::HELP:
+            {
+                parser.show_help();
+                break;
+            }
+        }
+
+    });
+    return agent_thread;
+}
+
+#ifndef _WIN32
+template <>
+std::thread create_agent_thread<eprosima::uxr::TermiosAgent>(
+        int argc,
+        char** argv,
+        eprosima::uxr::agent::TransportKind transport_kind,
+        const sigset_t* signals)
+{
+    std::thread agent_thread = std::thread([&]()
+    {
+        eprosima::uxr::agent::parser::ArgumentParser<eprosima::uxr::TermiosAgent>
+            parser(argc, argv, transport_kind);
+
+        switch (parser.parse_arguments())
+        {
+            case parser::ParseResult::INVALID:
+            {
+                return parser::utils::usage();
+                break;
+            }
+            case parser::ParseResult::VALID:
+            {
+                if (parser.launch_termios_agent())
+                {
+                    /* Wait for defined signals. */
+                    int n_signal = 0;
+                    sigwait(signals, &n_signal);
+                }
+                break;
+            }
+            case parser::ParseResult::HELP:
+            {
+                parser.show_help();
+                break;
+            }
+        }
+    });
+    return agent_thread;
+}
+
+template <>
+std::thread create_agent_thread<eprosima::uxr::PseudoTerminalAgent>(
+        int argc,
+        char** argv,
+        eprosima::uxr::agent::TransportKind transport_kind,
+        const sigset_t* signals)
+{
+    std::thread agent_thread = std::thread([&]()
+    {
+        eprosima::uxr::agent::parser::ArgumentParser<eprosima::uxr::PseudoTerminalAgent>
+            parser(argc, argv, transport_kind);
+
+        switch (parser.parse_arguments())
+        {
+            case parser::ParseResult::INVALID:
+            {
+                return parser::utils::usage();
+                break;
+            }
+            case parser::ParseResult::VALID:
+            {
+                if (parser.launch_pseudoterminal_agent())
+                {
+                    /* Wait for defined signals. */
+                    int n_signal = 0;
+                    sigwait(signals, &n_signal);
+                }
+                break;
+            }
+            case parser::ParseResult::HELP:
+            {
+                parser.show_help();
+                break;
+            }
+        }
+    });
+    return agent_thread;
+}
+#endif // _WIN32
+
+} // namespace agent
+} // namespace uxr
+} // namespace eprosima
+
+#endif // UXR_AGENT_UTILS_ARGUMENTPARSER_HPP_

--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -64,8 +64,12 @@ template <typename AgentKind>
 std::thread create_agent_thread(
         int argc,
         char** argv,
+#ifndef _WIN32
         TransportKind transport_kind,
         const sigset_t* signals);
+#else
+        TransportKind transport_kind);
+#endif // _WIN32
 
 namespace parser {
 namespace utils {
@@ -838,8 +842,12 @@ template <typename AgentKind>
 std::thread create_agent_thread(
         int argc,
         char** argv,
+#ifndef _WIN32
         eprosima::uxr::agent::TransportKind transport_kind,
         const sigset_t* signals)
+#else
+        eprosima::uxr::agent::TransportKind transport_kind)
+#endif // _WIN32
 {
     std::thread agent_thread = std::thread([&]()
     {
@@ -888,8 +896,12 @@ template <>
 std::thread create_agent_thread<eprosima::uxr::TermiosAgent>(
         int argc,
         char** argv,
+#ifndef _WIN32
         eprosima::uxr::agent::TransportKind transport_kind,
         const sigset_t* signals)
+#else
+        eprosima::uxr::agent::TransportKind transport_kind)
+#endif // _WIN32
 {
     std::thread agent_thread = std::thread([&]()
     {
@@ -927,8 +939,12 @@ template <>
 std::thread create_agent_thread<eprosima::uxr::PseudoTerminalAgent>(
         int argc,
         char** argv,
+#ifndef _WIN32
         eprosima::uxr::agent::TransportKind transport_kind,
         const sigset_t* signals)
+#else
+        eprosima::uxr::agent::TransportKind transport_kind)
+#endif // _WIN32
 {
     std::thread agent_thread = std::thread([&]()
     {

--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -849,7 +849,7 @@ std::thread create_agent_thread(
         eprosima::uxr::agent::TransportKind transport_kind)
 #endif // _WIN32
 {
-    std::thread agent_thread = std::thread([&]()
+    std::thread agent_thread = std::thread([&]() -> void
     {
         eprosima::uxr::agent::parser::ArgumentParser<AgentKind> parser(argc, argv, transport_kind);
 
@@ -857,7 +857,7 @@ std::thread create_agent_thread(
         {
             case parser::ParseResult::INVALID:
             {
-                return parser::utils::usage();
+                parser::utils::usage();
                 break;
             }
             case parser::ParseResult::VALID:
@@ -903,7 +903,7 @@ std::thread create_agent_thread<eprosima::uxr::TermiosAgent>(
         eprosima::uxr::agent::TransportKind transport_kind)
 #endif // _WIN32
 {
-    std::thread agent_thread = std::thread([&]()
+    std::thread agent_thread = std::thread([&]() -> void
     {
         eprosima::uxr::agent::parser::ArgumentParser<eprosima::uxr::TermiosAgent>
             parser(argc, argv, transport_kind);
@@ -912,7 +912,7 @@ std::thread create_agent_thread<eprosima::uxr::TermiosAgent>(
         {
             case parser::ParseResult::INVALID:
             {
-                return parser::utils::usage();
+                parser::utils::usage();
                 break;
             }
             case parser::ParseResult::VALID:
@@ -946,7 +946,7 @@ std::thread create_agent_thread<eprosima::uxr::PseudoTerminalAgent>(
         eprosima::uxr::agent::TransportKind transport_kind)
 #endif // _WIN32
 {
-    std::thread agent_thread = std::thread([&]()
+    std::thread agent_thread = std::thread([&]() -> void
     {
         eprosima::uxr::agent::parser::ArgumentParser<eprosima::uxr::PseudoTerminalAgent>
             parser(argc, argv, transport_kind);
@@ -955,7 +955,7 @@ std::thread create_agent_thread<eprosima::uxr::PseudoTerminalAgent>(
         {
             case parser::ParseResult::INVALID:
             {
-                return parser::utils::usage();
+                parser::utils::usage();
                 break;
             }
             case parser::ParseResult::VALID:

--- a/src/cpp/transport/serial/PseudoTerminalAgentLinux.cpp
+++ b/src/cpp/transport/serial/PseudoTerminalAgentLinux.cpp
@@ -67,6 +67,7 @@ bool PseudoTerminalAgent::init()
         cfsetispeed(&attrs, baudrate_);
         cfsetospeed(&attrs, baudrate_);
         tcsetattr(poll_fd_.fd, TCSANOW, &attrs);
+        rv = true;
     }
     else
     {

--- a/src/cpp/transport/serial/TermiosAgentLinux.cpp
+++ b/src/cpp/transport/serial/TermiosAgentLinux.cpp
@@ -97,8 +97,9 @@ bool TermiosAgent::init()
     {
         UXR_AGENT_LOG_ERROR(
             UXR_DECORATE_RED("open device error"),
-            "device: {}, errno: {}",
-            dev_, errno);
+            "device: {}, errno: {}{}",
+            dev_, errno,
+            (EACCES == errno) ? ". Please re-run with superuser privileges." : "");
     }
     return rv;
 }


### PR DESCRIPTION
This PR addresses the following changes:
* Disable CLI11 library, via CMakeLists option.
* Provide with a built-in argument parser, in case CLI profile is disabled.
* Fix `PseudoTerminalAgent::start()` method not returning `true` when initialization was performed successfully.
* Updates foonathan tag to working version