### PR TITLE
Hotfix: fix micro-ROS Agent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,11 @@ option(UAGENT_LOGGER_PROFILE "Build logger profile." ON)
 option(UAGENT_SECURITY_PROFILE "Build security profile." OFF)
 option(UAGENT_CLI_PROFILE "Build CLI profile." ON)
 option(UAGENT_BUILD_EXECUTABLE "Build MicroXRCE-DDS Agent provided executable." ON)
-if(NOT UAGENT_BUILD_EXECUTABLE)
-    set(UAGENT_CLI_PROFILE OFF)
-endif()
+
+### Do not uncomment these lines while micro-ROS Agent depends on CLI library
+#if(NOT UAGENT_BUILD_EXECUTABLE)
+#    set(UAGENT_CLI_PROFILE OFF)
+#endif()
 
 option(UAGENT_BUILD_CI_TESTS "Build CI test cases.")
 if(UAGENT_BUILD_CI_TESTS)


### PR DESCRIPTION
micro-ROS Agent uses the CLI_PROFILE approach. Disabling CLI_PROFILE results in `micro_ros_agent` executable not being compiled.
