### PR TITLE
Parse arguments to thread by value instead of reference (#183)

### DIFF
--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -814,7 +814,7 @@ inline std::thread create_agent_thread(
         eprosima::uxr::agent::TransportKind transport_kind)
 #endif // _WIN32
 {
-    std::thread agent_thread = std::thread([&]() -> void
+    std::thread agent_thread = std::thread([=]() -> void
     {
         eprosima::uxr::agent::parser::ArgumentParser<AgentKind> parser(argc, argv, transport_kind);
 
@@ -865,7 +865,7 @@ inline std::thread create_agent_thread<eprosima::uxr::TermiosAgent>(
         eprosima::uxr::agent::TransportKind transport_kind,
         const sigset_t* signals)
 {
-    std::thread agent_thread = std::thread([&]() -> void
+    std::thread agent_thread = std::thread([=]() -> void
     {
         eprosima::uxr::agent::parser::ArgumentParser<eprosima::uxr::TermiosAgent>
             parser(argc, argv, transport_kind);
@@ -905,7 +905,7 @@ inline std::thread create_agent_thread<eprosima::uxr::PseudoTerminalAgent>(
         eprosima::uxr::agent::TransportKind transport_kind,
         const sigset_t* signals)
 {
-    std::thread agent_thread = std::thread([&]() -> void
+    std::thread agent_thread = std::thread([=]() -> void
     {
         eprosima::uxr::agent::parser::ArgumentParser<eprosima::uxr::PseudoTerminalAgent>
             parser(argc, argv, transport_kind);


### PR DESCRIPTION
* Parse arguments to thread by value instead of reference

Parsing the arguments by reference (that exist on the stack) creates
a race condition. The thread may execute after the stack was destroyed
causing a segfault.

* Add missing cases for create_agent_thread template specialization

Co-authored-by: Jose Antonio Moral <joseantoniomoralparras@gmail.com>