### PR TITLE
Change default discovery port

### DIFF
--- a/include/uxr/agent/config.hpp.in
+++ b/include/uxr/agent/config.hpp.in
@@ -30,7 +30,7 @@ namespace uxr {
 #cmakedefine UAGENT_LOGGER_PROFILE
 #cmakedefine UAGENT_CLI_PROFILE
 
-const uint16_t DISCOVERY_PORT = 7400;
+const uint16_t DISCOVERY_PORT = 7401;
 const char* const DISCOVERY_IP = "239.255.0.2";
 
 const uint16_t RELIABLE_STREAM_DEPTH = @UAGENT_CONFIG_RELIABLE_STREAM_DEPTH@;

--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -42,7 +42,7 @@
 
 #define DEFAULT_MIDDLEWARE      "dds"
 #define DEFAULT_VERBOSE_LEVEL   4
-#define DEFAULT_DISCOVERY_PORT  7400
+#define DEFAULT_DISCOVERY_PORT  7401
 #define DEFAULT_BAUDRATE_LEVEL  "115200"
 
 namespace eprosima {

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -5,7 +5,7 @@ snapctl set transport=udp4
 snapctl set middleware=dds
 snapctl set verbosity=4
 snapctl set discovery=false
-snapctl set discovery-port=7400
+snapctl set discovery-port=7401
 snapctl set p2p-port!  # unset
 
 # Network-specific things

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,7 +51,7 @@ description: |
         $ snap set micro-xrce-dds-agent discovery="true or false"
 
   * `discovery-port`. Port on which the discovery server (see above)
-    listens. Defaults to 7400. Change with:
+    listens. Defaults to 7401. Change with:
 
         $ snap set micro-xrce-dds-agent discovery-port="selected port"
 


### PR DESCRIPTION
This PR changes the default discovery port defined in DDS-XRCE standard (https://www.omg.org/spec/DDS-XRCE/1.0/PDF page 94) because it interferes with traffic generated in Fast-DDS in the same port.

Before merge, it is necessary to determine why and how Fast-DDS generates traffic in this port.

Related:

https://github.com/eProsima/Micro-XRCE-DDS-Client/pull/171