### PR TITLE
Improve usage message: fetch executable name

### DIFF
--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -78,6 +78,7 @@ namespace parser {
 namespace utils {
 
 bool usage(
+        const char* executable_name,
         bool no_help = true);
 
 TransportKind check_transport(
@@ -794,7 +795,7 @@ public:
 
     void show_help()
     {
-        utils::usage(false);
+        utils::usage(argv_[0], false);
         std::stringstream ss;
         ss << std::endl << "Available arguments (per transport):" << std::endl;
         ss << "  * COMMON" << std::endl;
@@ -845,7 +846,7 @@ inline std::thread create_agent_thread(
             case parser::ParseResult::INVALID:
             case parser::ParseResult::NOT_FOUND:
             {
-                parser::utils::usage();
+                parser::utils::usage(argv[0]);
                 break;
             }
             case parser::ParseResult::VALID:
@@ -897,7 +898,7 @@ inline std::thread create_agent_thread<eprosima::uxr::TermiosAgent>(
             case parser::ParseResult::INVALID:
             case parser::ParseResult::NOT_FOUND:
             {
-                parser::utils::usage();
+                parser::utils::usage(argv[0]);
                 break;
             }
             case parser::ParseResult::VALID:
@@ -937,7 +938,7 @@ inline std::thread create_agent_thread<eprosima::uxr::PseudoTerminalAgent>(
             case parser::ParseResult::INVALID:
             case parser::ParseResult::NOT_FOUND:
             {
-                parser::utils::usage();
+                parser::utils::usage(argv[0]);
                 break;
             }
             case parser::ParseResult::VALID:

--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -78,7 +78,7 @@ namespace parser {
 namespace utils {
 
 bool usage(
-        const char* executable_name,
+        char* executable_name,
         bool no_help = true);
 
 TransportKind check_transport(

--- a/src/cpp/AgentInstance.cpp
+++ b/src/cpp/AgentInstance.cpp
@@ -87,7 +87,7 @@ bool AgentInstance::create(
     // Use built-in argument parser
     if (2 > argc)
     {
-        agent::parser::utils::usage();
+        agent::parser::utils::usage(argv[0]);
         return false;
     }
     const char* chosen_transport(argv[1]);
@@ -155,7 +155,7 @@ bool AgentInstance::create(
         case agent::TransportKind::INVALID:
         {
             std::cerr << "Error: chosen transport '" << chosen_transport << "' is invalid!" << std::endl;
-            agent::parser::utils::usage();
+            agent::parser::utils::usage(argv[0]);
             return false;
         }
     }

--- a/src/cpp/utils/ArgumentParser.cpp
+++ b/src/cpp/utils/ArgumentParser.cpp
@@ -20,10 +20,11 @@
 // TODO(jamoralp): move definitions of ArgumentParser.hpp into this file, to maintain code coherence.
 
 bool eprosima::uxr::agent::parser::utils::usage(
+        const char* executable_name,
         bool no_help)
 {
     std::stringstream ss;
-    ss << "Usage: 'MicroXRCEAgent <udp4|udp6|tcp4|tpc6";
+    ss << "Usage: '" << executable_name << " <udp4|udp6|tcp4|tpc6";
 #ifndef _WIN32
     ss << "|serial|pseudoterminal";
 #endif // _WIN32


### PR DESCRIPTION
Fix help when executable is not named MicroXRCEAgent, as in micro_ros_agent.