### PR TITLE
Add flush to open serial port

### DIFF
--- a/src/cpp/transport/Server.cpp
+++ b/src/cpp/transport/Server.cpp
@@ -26,8 +26,7 @@
 
 #include <functional>
 
-#define RECEIVE_TIMEOUT 1
-#define RECEIVE_TIMEOUT_MULTI 1000   // Milliseconds
+#define RECEIVE_TIMEOUT 1000   // Milliseconds
 
 namespace eprosima {
 namespace uxr {
@@ -213,7 +212,7 @@ void Server<MultiSerialEndPoint>::receiver_loop()
     while (running_cond_)
     {
         TransportRc transport_rc = TransportRc::ok;
-        if (recv_message(input_packet, RECEIVE_TIMEOUT_MULTI, transport_rc))
+        if (recv_message(input_packet, RECEIVE_TIMEOUT, transport_rc))
         {
             for (auto & element : input_packet)
             {

--- a/src/cpp/transport/serial/TermiosAgentLinux.cpp
+++ b/src/cpp/transport/serial/TermiosAgentLinux.cpp
@@ -110,6 +110,8 @@ bool TermiosAgent::init()
                 rv = true;
                 poll_fd_.events = POLLIN;
 
+                tcflush(poll_fd_.fd, TCIOFLUSH);
+
                 UXR_AGENT_LOG_INFO(
                     UXR_DECORATE_GREEN("running..."),
                     "fd: {}",


### PR DESCRIPTION
Add flush after serial port is opened, to avoid processing previous messages.
Also, server read timeout was 1 millisecond, changed to 1 second.
