### PR TITLE
Add Linux transport code to Android build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ endif()
 # Sources
 ###############################################################################
 # Check platform.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
     set(TRANSPORT_SRCS
         src/cpp/transport/udp/UDPv4AgentLinux.cpp
         src/cpp/transport/udp/UDPv6AgentLinux.cpp

--- a/include/uxr/agent/transport/endpoint/CustomEndPoint.hpp
+++ b/include/uxr/agent/transport/endpoint/CustomEndPoint.hpp
@@ -450,7 +450,7 @@ public:
     }
 
 private:
-    std::map<const std::string, Member> members_;
+    std::map<std::string, Member> members_;
 };
 
 /**

--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -996,8 +996,12 @@ public:
 
         /* Setting baudrate. */
         speed_t baudrate = getBaudRate(baudrate_str);
+#if _HAVE_STRUCT_TERMIOS_C_ISPEED
         attr.c_ispeed = baudrate;
+#endif
+#if _HAVE_STRUCT_TERMIOS_C_OSPEED
         attr.c_ospeed = baudrate;
+#endif
 
         return attr;
     }

--- a/src/cpp/transport/serial/MultiTermiosAgentLinux.cpp
+++ b/src/cpp/transport/serial/MultiTermiosAgentLinux.cpp
@@ -85,8 +85,12 @@ void MultiTermiosAgent::init_multiport()
                         new_attrs.c_cc[VMIN] = termios_attrs_.c_cc[VMIN];
                         new_attrs.c_cc[VTIME] = termios_attrs_.c_cc[VTIME];
 
+#if _HAVE_STRUCT_TERMIOS_C_ISPEED
                         cfsetispeed(&new_attrs, termios_attrs_.c_ispeed);
+#endif
+#if _HAVE_STRUCT_TERMIOS_C_OSPEED
                         cfsetospeed(&new_attrs, termios_attrs_.c_ospeed);
+#endif
 
                         if (0 == tcsetattr(aux_poll_fd.fd, TCSANOW, &new_attrs))
                         {

--- a/src/cpp/transport/serial/TermiosAgentLinux.cpp
+++ b/src/cpp/transport/serial/TermiosAgentLinux.cpp
@@ -102,8 +102,12 @@ bool TermiosAgent::init()
             new_attrs.c_cc[VMIN] = termios_attrs_.c_cc[VMIN];
             new_attrs.c_cc[VTIME] = termios_attrs_.c_cc[VTIME];
 
+#if _HAVE_STRUCT_TERMIOS_C_ISPEED
             cfsetispeed(&new_attrs, termios_attrs_.c_ispeed);
+#endif
+#if _HAVE_STRUCT_TERMIOS_C_OSPEED
             cfsetospeed(&new_attrs, termios_attrs_.c_ospeed);
+#endif
 
             if (0 == tcsetattr(poll_fd_.fd, TCSANOW, &new_attrs))
             {


### PR DESCRIPTION
```CMAKE_SYSTEM_NAME``` will be set to ```Android``` by Android NDK's toolchain file. This should never affect a normal build.