### PR TITLE
Fix compilation issues on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,8 @@ if(UAGENT_FAST_PROFILE)
 endif()
 
 if(UAGENT_LOGGER_PROFILE)
-    set(_spdlog_version 1.4.2)
-    set(_spdlog_tag v1.4.2)
+    set(_spdlog_version 1.9.2)
+    set(_spdlog_tag v1.9.2)
     list(APPEND _deps "spdlog\;${_spdlog_version}")
 endif()
 
@@ -154,6 +154,20 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
         src/cpp/transport/tcp/TCPv4AgentLinux.cpp
         src/cpp/transport/tcp/TCPv6AgentLinux.cpp
         src/cpp/transport/can/CanAgentLinux.cpp
+        src/cpp/transport/serial/SerialAgentLinux.cpp
+        src/cpp/transport/serial/TermiosAgentLinux.cpp
+        src/cpp/transport/serial/MultiSerialAgentLinux.cpp
+        src/cpp/transport/serial/MultiTermiosAgentLinux.cpp
+        src/cpp/transport/serial/PseudoTerminalAgentLinux.cpp
+        $<$<BOOL:${UAGENT_DISCOVERY_PROFILE}>:src/cpp/transport/discovery/DiscoveryServerLinux.cpp>
+        $<$<BOOL:${UAGENT_P2P_PROFILE}>:src/cpp/transport/p2p/AgentDiscovererLinux.cpp>
+        )
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(TRANSPORT_SRCS
+        src/cpp/transport/udp/UDPv4AgentLinux.cpp
+        src/cpp/transport/udp/UDPv6AgentLinux.cpp
+        src/cpp/transport/tcp/TCPv4AgentLinux.cpp
+        src/cpp/transport/tcp/TCPv6AgentLinux.cpp
         src/cpp/transport/serial/SerialAgentLinux.cpp
         src/cpp/transport/serial/TermiosAgentLinux.cpp
         src/cpp/transport/serial/MultiSerialAgentLinux.cpp

--- a/include/uxr/agent/transport/serial/baud_rate_table_linux.h
+++ b/include/uxr/agent/transport/serial/baud_rate_table_linux.h
@@ -149,7 +149,7 @@ speed_t getBaudRate(const char* baudrate_str)
     {
         rv = B4000000;
     }
-#endif
+#endif // __APPLE__
     else
     {
         speed_t custom_baud_rate = (speed_t)atoi(baudrate_str);

--- a/include/uxr/agent/transport/serial/baud_rate_table_linux.h
+++ b/include/uxr/agent/transport/serial/baud_rate_table_linux.h
@@ -100,6 +100,7 @@ speed_t getBaudRate(const char* baudrate_str)
     {
         rv = B230400;
     }
+#ifndef __APPLE__
     else if (0 == strcmp(baudrate_str, "460800"))
     {
         rv = B460800;
@@ -148,6 +149,7 @@ speed_t getBaudRate(const char* baudrate_str)
     {
         rv = B4000000;
     }
+#endif
     else
     {
         speed_t custom_baud_rate = (speed_t)atoi(baudrate_str);

--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -33,7 +33,9 @@
 #include <uxr/agent/transport/udp/UDPv6AgentLinux.hpp>
 #include <uxr/agent/transport/tcp/TCPv4AgentLinux.hpp>
 #include <uxr/agent/transport/tcp/TCPv6AgentLinux.hpp>
+#ifndef __APPLE__
 #include <uxr/agent/transport/can/CanAgentLinux.hpp>
+#endif // __APPLE__
 #include <uxr/agent/transport/serial/TermiosAgentLinux.hpp>
 #include <uxr/agent/transport/serial/MultiTermiosAgentLinux.hpp>
 #include <uxr/agent/transport/serial/PseudoTerminalAgentLinux.hpp>
@@ -61,7 +63,9 @@ enum class TransportKind
     TCP4,
     TCP6,
 #ifndef _WIN32
+#ifndef __APPLE__
     CAN,
+#endif // __APPLE__
     SERIAL,
     MULTISERIAL,
     PSEUDOTERMINAL,
@@ -867,7 +871,7 @@ private:
     Argument<std::string> file_;
 };
 
-
+#ifndef __APPLE__
 /*************************************************************************************************
  * Specific arguments for CAN transports
  *************************************************************************************************/
@@ -919,6 +923,7 @@ private:
     Argument<std::string> dev_;
     Argument<std::string> can_id_;
 };
+#endif // __APPLE__
 #endif // _WIN32
 
 /*************************************************************************************************
@@ -937,7 +942,9 @@ public:
         , common_args_()
         , ip_args_()
 #ifndef _WIN32
+#ifndef __APPLE__
         , can_args_()
+#endif // __APPLE__
         , serial_args_()
         , multiserial_args_()
         , pseudoterminal_args_()
@@ -971,11 +978,13 @@ public:
                 break;
             }
 #ifndef _WIN32
+#ifndef __APPLE__
             case TransportKind::CAN:
             {
                 result &= can_args_.parse(argc_, argv_);
                 break;
             }
+#endif // __APPLE__
             case TransportKind::SERIAL:
             {
                 result &= serial_args_.parse(argc_, argv_);
@@ -1081,8 +1090,10 @@ public:
         ss << "  * SERIAL (serial, multiserial, pseudoterminal)" << std::endl;
         ss << pseudoterminal_args_.get_help();
         ss << serial_args_.get_help();
+#ifndef __APPLE__
         ss << "  * CAN FD (canfd)" << std::endl;
         ss << can_args_.get_help();
+#endif // __APPLE__
 #endif // _WIN32
         ss << std::endl;
         // TODO(@jamoralp): Once documentation is updated with proper CLI section, add here an hyperlink to that section
@@ -1095,7 +1106,9 @@ private:
     CommonArgs<AgentType> common_args_;
     IPvXArgs<AgentType> ip_args_;
 #ifndef _WIN32
+#ifndef __APPLE__
     CanArgs<AgentType> can_args_;
+#endif // __APPLE__
     SerialArgs<AgentType> serial_args_;
     MultiSerialArgs<AgentType> multiserial_args_;
     PseudoTerminalArgs<AgentType> pseudoterminal_args_;

--- a/src/cpp/AgentInstance.cpp
+++ b/src/cpp/AgentInstance.cpp
@@ -64,11 +64,13 @@ bool AgentInstance::create(
             break;
         }
 #ifndef _WIN32
+#ifndef __APPLE__
         case agent::TransportKind::CAN:
         {
             agent_thread_ = std::move(agent::create_agent_thread<CanAgent>(argc, argv, exit_signal, valid_transport));
             break;
         }
+#endif  // __APPLE__
         case agent::TransportKind::SERIAL:
         {
             agent_thread_ = std::move(agent::create_agent_thread<TermiosAgent>(argc, argv, exit_signal, valid_transport));

--- a/src/cpp/utils/ArgumentParser.cpp
+++ b/src/cpp/utils/ArgumentParser.cpp
@@ -53,7 +53,9 @@ eprosima::uxr::agent::TransportKind eprosima::uxr::agent::parser::utils::check_t
     {"tcp4", eprosima::uxr::agent::TransportKind::TCP4},
     {"tcp6", eprosima::uxr::agent::TransportKind::TCP6},
 #ifndef _WIN32
+#ifndef __APPLE__
     {"canfd", eprosima::uxr::agent::TransportKind::CAN},
+#endif // __APPLE__
     {"serial", eprosima::uxr::agent::TransportKind::SERIAL},
     {"multiserial", eprosima::uxr::agent::TransportKind::MULTISERIAL},
     {"pseudoterminal", eprosima::uxr::agent::TransportKind::PSEUDOTERMINAL},


### PR DESCRIPTION
The current version of this project can not be compiled on macOS. There were 3 issues this pull request fixes:
1) spdlog 1.4.2 had linker issues when compiled with clang. A newer version of spdlog fixed that
2) The maximum baud rate defined in macOS is 230400.
3) The header `#include <linux/can.h>` does not exist on macOS, hence the `CanAgent` can't be used on macOS.