### PR TITLE
Add sub entities destruction on FastDDS entities

### DIFF
--- a/src/cpp/middleware/fastdds/FastDDSEntities.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSEntities.cpp
@@ -360,13 +360,16 @@ static void set_qos_from_xrce_object(
  **********************************************************************************************************************/
 FastDDSParticipant::~FastDDSParticipant()
 {
-    if (ptr_->has_active_entities())
+    if (ptr_)
     {
-        // TODO: Not available on foxy (Need FastDDS >= 2.2.0 for declaration and FastDDS >= 2.4.1 for implementation)
-        // ptr_->delete_contained_entities();
+        if (ptr_->has_active_entities())
+        {
+            // TODO: Not available on foxy (Need FastDDS >= 2.2.0 for declaration and FastDDS >= 2.4.1 for implementation)
+            // ptr_->delete_contained_entities();
+        }
+
+        factory_->delete_participant(ptr_);
     }
-    
-    factory_->delete_participant(ptr_);
 }
 
 bool FastDDSParticipant::create_by_ref(
@@ -495,6 +498,11 @@ fastdds::dds::Publisher* FastDDSParticipant::create_publisher(
 ReturnCode_t FastDDSParticipant::delete_publisher(
         fastdds::dds::Publisher* publisher)
 {
+    if (NULL == publisher)
+    {
+        return ReturnCode_t::RETCODE_ALREADY_DELETED;
+    }
+
     if (publisher->has_datawriters())
     {
         ReturnCode_t ret = ReturnCode_t::RETCODE_OK;
@@ -533,6 +541,11 @@ fastdds::dds::Subscriber* FastDDSParticipant::create_subscriber(
 ReturnCode_t FastDDSParticipant::delete_subscriber(
         fastdds::dds::Subscriber* subscriber)
 {
+    if (NULL == subscriber)
+    {
+        return ReturnCode_t::RETCODE_ALREADY_DELETED;
+    }
+
     if (subscriber->has_datareaders())
     {
         ReturnCode_t ret = ReturnCode_t::RETCODE_OK;
@@ -804,6 +817,11 @@ fastdds::dds::DataWriter* FastDDSPublisher::create_datawriter(
 ReturnCode_t FastDDSPublisher::delete_datawriter(
     fastdds::dds::DataWriter* writer)
 {
+    if (NULL == writer)
+    {
+        return ReturnCode_t::RETCODE_ALREADY_DELETED;
+    }
+
     return ptr_->delete_datawriter(writer);
 }
 
@@ -863,6 +881,11 @@ fastdds::dds::DataReader* FastDDSSubscriber::create_datareader(
 ReturnCode_t FastDDSSubscriber::delete_datareader(
         fastdds::dds::DataReader* reader)
 {
+    if (NULL == reader)
+    {
+        return ReturnCode_t::RETCODE_ALREADY_DELETED;
+    }
+
     return ptr_->delete_datareader(reader);
 }
 

--- a/src/cpp/middleware/fastdds/FastDDSEntities.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSEntities.cpp
@@ -362,9 +362,9 @@ FastDDSParticipant::~FastDDSParticipant()
 {
     if (ptr_)
     {
-        if (ptr_->has_active_entities())
+        // TODO: Not available on foxy (Need FastDDS >= 2.2.0 for declaration and FastDDS >= 2.4.1 for implementation)
+        // if (ptr_->has_active_entities())
         {
-            // TODO: Not available on foxy (Need FastDDS >= 2.2.0 for declaration and FastDDS >= 2.4.1 for implementation)
             // ptr_->delete_contained_entities();
         }
 

--- a/src/cpp/middleware/fastdds/FastDDSEntities.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSEntities.cpp
@@ -360,6 +360,12 @@ static void set_qos_from_xrce_object(
  **********************************************************************************************************************/
 FastDDSParticipant::~FastDDSParticipant()
 {
+    if (ptr_->has_active_entities())
+    {
+        // TODO: Not available on foxy (Need FastDDS >= 2.2.0 for declaration and FastDDS >= 2.4.1 for implementation)
+        // ptr_->delete_contained_entities();
+    }
+    
     factory_->delete_participant(ptr_);
 }
 
@@ -489,6 +495,30 @@ fastdds::dds::Publisher* FastDDSParticipant::create_publisher(
 ReturnCode_t FastDDSParticipant::delete_publisher(
         fastdds::dds::Publisher* publisher)
 {
+    if (publisher->has_datawriters())
+    {
+        ReturnCode_t ret = ReturnCode_t::RETCODE_OK;
+
+        // TODO: Not available on foxy (Need FastDDS >= 2.2.0 for declaration and FastDDS >= 2.4.1 for implementation)
+        // ret = publisher->delete_contained_entities();
+
+        //if (ReturnCode_t::RETCODE_UNSUPPORTED == ret)
+        {
+            std::vector<eprosima::fastdds::dds::DataWriter*> writers;
+            publisher->get_datawriters(writers);
+
+            for (auto datawriter : writers)
+            {
+                ret = publisher->delete_datawriter(datawriter);
+
+                if (ReturnCode_t::RETCODE_OK != ret)
+                {
+                    return ret;
+                }
+            }
+        }       
+    }
+
     return ptr_->delete_publisher(publisher);
 }
 
@@ -503,6 +533,30 @@ fastdds::dds::Subscriber* FastDDSParticipant::create_subscriber(
 ReturnCode_t FastDDSParticipant::delete_subscriber(
         fastdds::dds::Subscriber* subscriber)
 {
+    if (subscriber->has_datareaders())
+    {
+        ReturnCode_t ret = ReturnCode_t::RETCODE_OK;
+
+        // TODO: Not available on foxy (Need FastDDS >= 2.2.0 for declaration and FastDDS >= 2.4.1 for implementation)
+        // ret = subscriber->delete_contained_entities();
+
+        // if (ReturnCode_t::RETCODE_UNSUPPORTED == ret)
+        {
+            std::vector<eprosima::fastdds::dds::DataReader*> readers;
+            subscriber->get_datareaders(readers);
+
+            for (auto datareader : readers)
+            {
+                ret = subscriber->delete_datareader(datareader);
+
+                if (ReturnCode_t::RETCODE_OK != ret)
+                {
+                    return ret;
+                }
+            }
+        }       
+    }
+
     return ptr_->delete_subscriber(subscriber);
 }
 


### PR DESCRIPTION
Internal DataWriters and DataReaders were not being deleted on Agent FastDDS Publisher and Subscriber delete methods:
https://github.com/eProsima/Micro-XRCE-DDS-Agent/blob/904221fdf69cfce712e4ad78a7784d6c7901c1a1/src/cpp/middleware/fastdds/FastDDSEntities.cpp#L489-L493

This implies that `delete_publisher` may fail, as explained on [FastDDS documentation](https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/publisher/publisher/createPublisher.html#deleting-a-publisher):

> A Publisher can only be deleted if all Entities belonging to the Publisher (DataWriters) have already been deleted. Otherwise, the function will issue an error and the Publisher will not be deleted.

This bug caused a thread/memory leak and random response problems using services/clients with reconnection patterns as detected on [this issue](https://github.com/micro-ROS/micro_ros_setup/issues/434).

It didn't affect regular publishers/subscribers, as micro-ROS `rmw_microxrcedds` destroy methods handles the internal datawriter/reader destruction: [detail](https://github.com/micro-ROS/rmw_microxrcedds/blob/galactic/rmw_microxrcedds_c/src/rmw_publisher.c#L348-L362).