### PR TITLE
Add reuse socket to TCP agent

### DIFF
--- a/src/cpp/transport/tcp/TCPv4AgentLinux.cpp
+++ b/src/cpp/transport/tcp/TCPv4AgentLinux.cpp
@@ -83,6 +83,15 @@ bool TCPv4Agent::init()
 
     if (-1 != listener_poll_.fd)
     {
+        int value = 1;
+        if (0 == setsockopt(listener_poll_.fd, SOL_SOCKET, SO_REUSEADDR, &value, sizeof(value)))
+        {
+            UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_YELLOW("SO_REUSEADDR socket option failed"),
+                    "port: {}, errno: {}",
+                    agent_port_, errno);
+        }
+
         struct sockaddr_in address;
 
         address.sin_family = AF_INET;

--- a/src/cpp/transport/tcp/TCPv4AgentLinux.cpp
+++ b/src/cpp/transport/tcp/TCPv4AgentLinux.cpp
@@ -84,7 +84,7 @@ bool TCPv4Agent::init()
     if (-1 != listener_poll_.fd)
     {
         int value = 1;
-        if (0 == setsockopt(listener_poll_.fd, SOL_SOCKET, SO_REUSEADDR, &value, sizeof(value)))
+        if (0 != setsockopt(listener_poll_.fd, SOL_SOCKET, SO_REUSEADDR, &value, sizeof(value)))
         {
             UXR_AGENT_LOG_ERROR(
                     UXR_DECORATE_YELLOW("SO_REUSEADDR socket option failed"),


### PR DESCRIPTION
This options allows the agent to reuse the socket from a previously closed agent.
Otherwise we need to wait for the tcp `TIME_WAIT` timeout.

CI: https://github.com/eProsima/Micro-XRCE-DDS/pull/130