### PR TITLE
Fix select() timeout format

### DIFF
--- a/src/cpp/transport/serial/MultiTermiosAgentLinux.cpp
+++ b/src/cpp/transport/serial/MultiTermiosAgentLinux.cpp
@@ -97,6 +97,7 @@ void MultiTermiosAgent::init_multiport()
                             // Add open port to MultiSerialAgent
                             insert_serial(aux_poll_fd.fd);
                             initialized_devs_.insert(std::pair<int, std::string>(aux_poll_fd.fd, it->second));
+                            tcflush(aux_poll_fd.fd, TCIOFLUSH);
 
                             UXR_AGENT_LOG_INFO(
                                 UXR_DECORATE_GREEN("Serial port running..."),


### PR DESCRIPTION
For certain ARM architectures, select returned the following `errno` for `tv_usec >= 1 second`:
> EINVAL The value contained within timeout is invalid.
