### PR TITLE
Fix exception on Heartbeat filter

### DIFF
--- a/src/cpp/transport/Server.cpp
+++ b/src/cpp/transport/Server.cpp
@@ -192,7 +192,7 @@ void Server<EndPoint>::receiver_loop()
         TransportRc transport_rc = TransportRc::ok;
         if (recv_message(input_packet, RECEIVE_TIMEOUT, transport_rc))
         {
-            if(dds::xrce::HEARTBEAT == input_packet.message->get_submessage_id() && 1U == input_packet.message->count_submessages()){
+            if(input_packet.message->is_valid_xrce_message() && 1U == input_packet.message->count_submessages() && dds::xrce::HEARTBEAT == input_packet.message->get_submessage_id()){
                 input_scheduler_.push(std::move(input_packet), 1);
             }
             else


### PR DESCRIPTION
In order to prioritize Heartbeats in the incoming XRCE message queue, the incoming XRCE submessage is pre-deserialized to check: 
1. There is one and only one submessage in the message
2. This submessage is a Heartbeat.

In order to do so, some check has to be done in order to avoid wrong or invalid XRCE messages.