### PR TITLE
Allow overriding the client's domain ID through reference

### DIFF
--- a/include/uxr/agent/middleware/Middleware.hpp
+++ b/include/uxr/agent/middleware/Middleware.hpp
@@ -25,6 +25,8 @@
 #include <functional>
 #include <chrono>
 
+#define UXR_CLIENT_DOMAIN_ID_TO_USE_FROM_REF (255)
+
 namespace eprosima {
 namespace uxr {
 

--- a/src/cpp/middleware/fast/FastMiddleware.cpp
+++ b/src/cpp/middleware/fast/FastMiddleware.cpp
@@ -49,7 +49,9 @@ bool FastMiddleware::create_participant_by_ref(
     fastrtps::ParticipantAttributes attrs;
     if (XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(ref, attrs))
     {
-        attrs.domainId = uint32_t(domain_id);
+        if(domain_id != UXR_CLIENT_DOMAIN_ID_TO_USE_FROM_REF) {
+            attrs.domainId = domain_id;
+        }
         fastrtps::Participant* impl = fastrtps::Domain::createParticipant(attrs, &listener_);
         if (nullptr != impl)
         {
@@ -773,7 +775,9 @@ bool FastMiddleware::matched_participant_from_ref(
         fastrtps::ParticipantAttributes attrs;
         if (XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(ref, attrs))
         {
-            attrs.domainId = uint32_t(domain_id);
+            if(domain_id != UXR_CLIENT_DOMAIN_ID_TO_USE_FROM_REF) {
+                attrs.domainId = domain_id;
+            }
             rv = it->second->match(attrs);
         }
     }

--- a/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
@@ -62,7 +62,13 @@ bool FastDDSMiddleware::create_participant_by_ref(
         const std::string& ref)
 {
     bool rv = false;
-    std::shared_ptr<FastDDSParticipant> participant(new FastDDSParticipant(domain_id));
+    fastrtps::ParticipantAttributes attrs;
+    auto participant_domain_id = domain_id;
+    if(domain_id == UXR_CLIENT_DOMAIN_ID_TO_USE_FROM_REF && XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(ref, attrs))
+    {
+        participant_domain_id = attrs.domainId;
+    }
+    std::shared_ptr<FastDDSParticipant> participant(new FastDDSParticipant(participant_domain_id));
     if (participant->create_by_ref(ref))
     {
         auto emplace_res = participants_.emplace(participant_id, std::move(participant));
@@ -986,7 +992,13 @@ bool FastDDSMiddleware::matched_participant_from_ref(
     auto it = participants_.find(participant_id);
     if (participants_.end() != it)
     {
-        rv = (domain_id == it->second->domain_id()) && (it->second->match_from_ref(ref));
+        fastrtps::ParticipantAttributes attrs;
+        auto participant_domain_id = domain_id;
+        if(domain_id == UXR_CLIENT_DOMAIN_ID_TO_USE_FROM_REF && XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(ref, attrs))
+        {
+            participant_domain_id = attrs.domainId;
+        }
+        rv = (participant_domain_id== it->second->domain_id()) && (it->second->match_from_ref(ref));
     }
     return rv;
 }

--- a/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
@@ -66,7 +66,7 @@ bool FastDDSMiddleware::create_participant_by_ref(
     auto participant_domain_id = domain_id;
     if(domain_id == UXR_CLIENT_DOMAIN_ID_TO_USE_FROM_REF && XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(ref, attrs))
     {
-        participant_domain_id = attrs.domainId;
+        participant_domain_id = static_cast<int16_t>(attrs.domainId);
     }
     std::shared_ptr<FastDDSParticipant> participant(new FastDDSParticipant(participant_domain_id));
     if (participant->create_by_ref(ref))
@@ -996,7 +996,7 @@ bool FastDDSMiddleware::matched_participant_from_ref(
         auto participant_domain_id = domain_id;
         if(domain_id == UXR_CLIENT_DOMAIN_ID_TO_USE_FROM_REF && XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(ref, attrs))
         {
-            participant_domain_id = attrs.domainId;
+            participant_domain_id = static_cast<int16_t>(attrs.domainId);
         }
         rv = (participant_domain_id== it->second->domain_id()) && (it->second->match_from_ref(ref));
     }


### PR DESCRIPTION
As discussed on micro-ros/micro-ros-agent#182

The way this works is that if you set the domain-id to 255 on the client (an ID which is otherwise outside of the allowed range), it will be overridden by the value specified in the reference.