### PR TITLE
Override domain_id with ROS_DOMAIN_ID provided by the agent

### DIFF
--- a/include/uxr/agent/middleware/Middleware.hpp
+++ b/include/uxr/agent/middleware/Middleware.hpp
@@ -26,6 +26,7 @@
 #include <chrono>
 
 #define UXR_CLIENT_DOMAIN_ID_TO_USE_FROM_REF (255)
+#define UXR_CLIENT_DOMAIN_ID_TO_OVERRIDE_WITH_ENV (255)
 
 namespace eprosima {
 namespace uxr {
@@ -298,7 +299,7 @@ public:
 /**********************************************************************************************************************
  * Members.
  **********************************************************************************************************************/
-protected: 
+protected:
     bool intraprocess_enabled_;
 };
 

--- a/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
+++ b/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
@@ -284,9 +284,9 @@ private:
         std::shared_ptr<FastDDSParticipant>& participant,
         const fastrtps::ReplierAttributes& attrs);
 
-    uint8_t get_domain_id_from_env();
+    int16_t get_domain_id_from_env();
 
-    uint8_t agent_domain_id_ = 0;
+    int16_t agent_domain_id_ = 0;
     std::unordered_map<uint16_t, std::shared_ptr<FastDDSParticipant>> participants_;
     std::unordered_map<uint16_t, std::shared_ptr<FastDDSTopic>> topics_;
     std::unordered_map<uint16_t, std::shared_ptr<FastDDSPublisher>> publishers_;

--- a/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
+++ b/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
@@ -284,6 +284,9 @@ private:
         std::shared_ptr<FastDDSParticipant>& participant,
         const fastrtps::ReplierAttributes& attrs);
 
+    uint8_t get_domain_id_from_env();
+
+    uint8_t agent_domain_id_ = 0;
     std::unordered_map<uint16_t, std::shared_ptr<FastDDSParticipant>> participants_;
     std::unordered_map<uint16_t, std::shared_ptr<FastDDSTopic>> topics_;
     std::unordered_map<uint16_t, std::shared_ptr<FastDDSPublisher>> publishers_;

--- a/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
@@ -1262,7 +1262,7 @@ bool FastDDSMiddleware::matched_replier_from_bin(
 
 int16_t FastDDSMiddleware::get_domain_id_from_env(){
     int16_t agent_domain_id = 0;
-    const char * agent_domain_id_env = std::getenv( "ROS_DOMAIN_ID" );
+    const char * agent_domain_id_env = std::getenv( "XRCE_DOMAIN_ID_OVERRIDE" );
     if (nullptr != agent_domain_id_env)
     {
         agent_domain_id = static_cast<int16_t>(std::atoi(agent_domain_id_env));

--- a/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
@@ -122,7 +122,8 @@ bool FastDDSMiddleware::create_participant_by_bin(
         participant_domain_id = agent_domain_id_;
         UXR_AGENT_LOG_WARN(
                 UXR_DECORATE_YELLOW("Overriding Micro XRCE-DDS Client DOMAIN_ID"),
-                "domain_id: {}", participant_domain_id);
+                "domain_id: {}", participant_domain_id
+        );
     }
 
     bool rv = false;

--- a/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
@@ -14,6 +14,7 @@
 
 #include <uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp>
 #include <uxr/agent/utils/Conversion.hpp>
+#include <uxr/agent/logger/Logger.hpp>
 
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
@@ -51,6 +52,14 @@ FastDDSMiddleware::FastDDSMiddleware(bool intraprocess_enabled)
     , repliers_()
     , callback_factory_(callback_factory_.getInstance())
 {
+    agent_domain_id_ = get_domain_id_from_env();
+    if (agent_domain_id_)
+    {
+        UXR_AGENT_LOG_INFO(
+                UXR_DECORATE_GREEN("Micro XRCE-DDS Agent DOMAIN_ID read from env"),
+                "domain_id: {}", agent_domain_id_);
+    }
+
 }
 
 /**********************************************************************************************************************
@@ -108,8 +117,16 @@ bool FastDDSMiddleware::create_participant_by_bin(
         uint16_t participant_id,
         const dds::xrce::OBJK_DomainParticipant_Binary& participant_xrce)
 {
+    auto participant_domain_id = static_cast<int16_t>(participant_xrce.domain_id());
+    if(participant_domain_id == UXR_CLIENT_DOMAIN_ID_TO_OVERRIDE_WITH_ENV){
+        participant_domain_id = static_cast<int16_t>(agent_domain_id_);
+        UXR_AGENT_LOG_WARN(
+                UXR_DECORATE_YELLOW("Overriding Micro XRCE-DDS Client DOMAIN_ID"),
+                "domain_id: {}", participant_domain_id);
+    }
+
     bool rv = false;
-    std::shared_ptr<FastDDSParticipant> participant(new FastDDSParticipant((int16_t) participant_xrce.domain_id()));
+    std::shared_ptr<FastDDSParticipant> participant(new FastDDSParticipant(participant_domain_id));
     if (participant->create_by_bin(participant_xrce))
     {
         auto emplace_res = participants_.emplace(participant_id, std::move(participant));
@@ -1240,6 +1257,16 @@ bool FastDDSMiddleware::matched_replier_from_bin(
         rv = it->second->match_from_bin(replier_xrce);
     }
     return rv;
+}
+
+uint8_t FastDDSMiddleware::get_domain_id_from_env(){
+    uint8_t agent_domain_id = 0;
+    const char * agent_domain_id_env = std::getenv( "ROS_DOMAIN_ID" );
+    if (nullptr != agent_domain_id_env)
+    {
+        agent_domain_id = std::atoi(agent_domain_id_env);
+    }
+    return agent_domain_id;
 }
 
 } // namespace uxr

--- a/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
@@ -119,7 +119,7 @@ bool FastDDSMiddleware::create_participant_by_bin(
 {
     auto participant_domain_id = static_cast<int16_t>(participant_xrce.domain_id());
     if(participant_domain_id == UXR_CLIENT_DOMAIN_ID_TO_OVERRIDE_WITH_ENV){
-        participant_domain_id = static_cast<int16_t>(agent_domain_id_);
+        participant_domain_id = agent_domain_id_;
         UXR_AGENT_LOG_WARN(
                 UXR_DECORATE_YELLOW("Overriding Micro XRCE-DDS Client DOMAIN_ID"),
                 "domain_id: {}", participant_domain_id);
@@ -1259,12 +1259,12 @@ bool FastDDSMiddleware::matched_replier_from_bin(
     return rv;
 }
 
-uint8_t FastDDSMiddleware::get_domain_id_from_env(){
-    uint8_t agent_domain_id = 0;
+int16_t FastDDSMiddleware::get_domain_id_from_env(){
+    int16_t agent_domain_id = 0;
     const char * agent_domain_id_env = std::getenv( "ROS_DOMAIN_ID" );
     if (nullptr != agent_domain_id_env)
     {
-        agent_domain_id = std::atoi(agent_domain_id_env);
+        agent_domain_id = static_cast<int16_t>(std::atoi(agent_domain_id_env));
     }
     return agent_domain_id;
 }


### PR DESCRIPTION
There was a need to select `ROS_DOMAIN_ID` in firmware without recompiling. Comparing this changes https://github.com/eProsima/Micro-XRCE-DDS-Agent/pull/322 and this PR https://github.com/eProsima/Micro-XRCE-DDS-Agent/pull/331 I prepared overriding client domain id. This change will override the clients domain (only when it is `255` - safe value due to the smaller domain limit) to the `ROS_DOMAIN_ID` configured as an environmental variable in e. g. micro-ros-agent docker container.  

Tested on Nucleo-L476RG publisher example and ROSbot 2R firmware.

Here are the changes inside firmware https://github.com/husarion/rosbot_ros2_firmware/pull/20.

I prepared prebuilt docker container with these changes `husarion/micro-ros-agent:humble-overrice-domain-id`. 

This is the example compose for ROSbot 2R or any microros serial client:
```yaml
  microros:
    image: husarion/micro-ros-agent:humble-overrice-domain-id
    network_mode: host
    ipc: host
    devices:
      - ${SERIAL_PORT:?err}
    environment:
      - SERIAL_PORT
      - RMW_IMPLEMENTATION=rmw_fastrtps_cpp
      - ROS_DOMAIN_ID=2
    command: serial -D $SERIAL_PORT serial -b 576000 # -v6
   ```
   
![image](https://github.com/eProsima/Micro-XRCE-DDS-Agent/assets/109142865/9df9d7fc-9837-4276-ba81-33e5f9b83082)

Best regards,
JD