### PR TITLE
Enable termios baudrate configuration for macOS

### DIFF
--- a/include/uxr/agent/utils/ArgumentParser.hpp
+++ b/include/uxr/agent/utils/ArgumentParser.hpp
@@ -1068,10 +1068,10 @@ public:
 
         /* Setting baudrate. */
         speed_t baudrate = getBaudRate(baudrate_str);
-#if _HAVE_STRUCT_TERMIOS_C_ISPEED
+#if _HAVE_STRUCT_TERMIOS_C_ISPEED || __APPLE__
         attr.c_ispeed = baudrate;
 #endif
-#if _HAVE_STRUCT_TERMIOS_C_OSPEED
+#if _HAVE_STRUCT_TERMIOS_C_OSPEED || __APPLE__
         attr.c_ospeed = baudrate;
 #endif
 

--- a/src/cpp/transport/serial/MultiTermiosAgentLinux.cpp
+++ b/src/cpp/transport/serial/MultiTermiosAgentLinux.cpp
@@ -85,10 +85,10 @@ void MultiTermiosAgent::init_multiport()
                         new_attrs.c_cc[VMIN] = termios_attrs_.c_cc[VMIN];
                         new_attrs.c_cc[VTIME] = termios_attrs_.c_cc[VTIME];
 
-#if _HAVE_STRUCT_TERMIOS_C_ISPEED
+#if _HAVE_STRUCT_TERMIOS_C_ISPEED || __APPLE__
                         cfsetispeed(&new_attrs, termios_attrs_.c_ispeed);
 #endif
-#if _HAVE_STRUCT_TERMIOS_C_OSPEED
+#if _HAVE_STRUCT_TERMIOS_C_OSPEED || __APPLE__
                         cfsetospeed(&new_attrs, termios_attrs_.c_ospeed);
 #endif
 

--- a/src/cpp/transport/serial/TermiosAgentLinux.cpp
+++ b/src/cpp/transport/serial/TermiosAgentLinux.cpp
@@ -102,10 +102,10 @@ bool TermiosAgent::init()
             new_attrs.c_cc[VMIN] = termios_attrs_.c_cc[VMIN];
             new_attrs.c_cc[VTIME] = termios_attrs_.c_cc[VTIME];
 
-#if _HAVE_STRUCT_TERMIOS_C_ISPEED
+#if _HAVE_STRUCT_TERMIOS_C_ISPEED || __APPLE__
             cfsetispeed(&new_attrs, termios_attrs_.c_ispeed);
 #endif
-#if _HAVE_STRUCT_TERMIOS_C_OSPEED
+#if _HAVE_STRUCT_TERMIOS_C_OSPEED || __APPLE__
             cfsetospeed(&new_attrs, termios_attrs_.c_ospeed);
 #endif
 


### PR DESCRIPTION
Closes #340

Ensure that the baud rate is set in the termios attributes when compiling with `clang` on macOS.
