### PR TITLE
Validate that received MTU is greater than 0 on client creation

### DIFF
--- a/src/cpp/Root.cpp
+++ b/src/cpp/Root.cpp
@@ -74,58 +74,70 @@ dds::xrce::ResultStatus Root::create_client(
     {
         if (client_representation.xrce_version()[0] == dds::xrce::XRCE_VERSION_MAJOR)
         {
-            std::lock_guard<std::mutex> lock(mtx_);
-            dds::xrce::ClientKey client_key = client_representation.client_key();
-            dds::xrce::SessionId session_id = client_representation.session_id();
-            auto it = clients_.find(client_key);
-            if (it == clients_.end())
+            if (client_representation.mtu() > 0)
             {
-                std::unordered_map<std::string, std::string> client_properties;
-
-                if (client_representation.properties())
+                std::lock_guard<std::mutex> lock(mtx_);
+                dds::xrce::ClientKey client_key = client_representation.client_key();
+                dds::xrce::SessionId session_id = client_representation.session_id();
+                auto it = clients_.find(client_key);
+                if (it == clients_.end())
                 {
-                    auto v = *client_representation.properties();
-                    for (auto it_props = v.begin(); it_props != v.end(); ++it_props)
+                    std::unordered_map<std::string, std::string> client_properties;
+
+                    if (client_representation.properties())
                     {
-                        client_properties.insert(std::pair<std::string, std::string>(it_props->name(), it_props->value()));
+                        auto v = *client_representation.properties();
+                        for (auto it_props = v.begin(); it_props != v.end(); ++it_props)
+                        {
+                            client_properties.insert(std::pair<std::string, std::string>(it_props->name(), it_props->value()));
+                        }
                     }
-                }
 
-                std::shared_ptr<ProxyClient> new_client = std::make_shared<ProxyClient>(
-                    client_representation,
-                    middleware_kind,
-                    std::move(client_properties));
-                if (clients_.emplace(client_key, std::move(new_client)).second)
-                {
-                    UXR_AGENT_LOG_INFO(
-                        UXR_DECORATE_GREEN("create"),
-                        UXR_CREATE_SESSION_PATTERN,
-                        conversion::clientkey_to_raw(client_key),
-                        session_id);
+                    std::shared_ptr<ProxyClient> new_client = std::make_shared<ProxyClient>(
+                        client_representation,
+                        middleware_kind,
+                        std::move(client_properties));
+                    if (clients_.emplace(client_key, std::move(new_client)).second)
+                    {
+                        UXR_AGENT_LOG_INFO(
+                            UXR_DECORATE_GREEN("create"),
+                            UXR_CREATE_SESSION_PATTERN,
+                            conversion::clientkey_to_raw(client_key),
+                            session_id);
+                    }
+                    else
+                    {
+                        result_status.status(dds::xrce::STATUS_ERR_RESOURCES);
+
+                        UXR_AGENT_LOG_INFO(
+                            UXR_DECORATE_RED("resources error"),
+                            UXR_CLIENT_KEY_PATTERN,
+                            conversion::clientkey_to_raw(client_representation.client_key()));
+                    }
                 }
                 else
                 {
-                    result_status.status(dds::xrce::STATUS_ERR_RESOURCES);
-
-                    UXR_AGENT_LOG_INFO(
-                        UXR_DECORATE_RED("resources error"),
-                        UXR_CLIENT_KEY_PATTERN,
-                        conversion::clientkey_to_raw(client_representation.client_key()));
+                    std::shared_ptr<ProxyClient> client = clients_.at(client_key);
+                    if (session_id != client->get_session_id())
+                    {
+                        it->second = std::make_shared<ProxyClient>(
+                            client_representation,
+                            middleware_kind);
+                    }
+                    else
+                    {
+                        client->session().reset();
+                    }
                 }
             }
             else
             {
-                std::shared_ptr<ProxyClient> client = clients_.at(client_key);
-                if (session_id != client->get_session_id())
-                {
-                    it->second = std::make_shared<ProxyClient>(
-                        client_representation,
-                        middleware_kind);
-                }
-                else
-                {
-                    client->session().reset();
-                }
+                result_status.status(dds::xrce::STATUS_ERR_INVALID_DATA);
+
+                UXR_AGENT_LOG_INFO(
+                    UXR_DECORATE_RED("invalid mtu"),
+                    UXR_CLIENT_KEY_PATTERN,
+                    conversion::clientkey_to_raw(client_representation.client_key()));
             }
         }
         else

--- a/src/cpp/Root.cpp
+++ b/src/cpp/Root.cpp
@@ -67,6 +67,19 @@ dds::xrce::ResultStatus Root::create_client(
         return invalid_result;
     }
 
+    if (client_representation.mtu() <= 0)
+    {
+        dds::xrce::ResultStatus invalid_result;
+        invalid_result.status(dds::xrce::STATUS_ERR_INVALID_DATA);
+
+        UXR_AGENT_LOG_INFO(
+            UXR_DECORATE_RED("invalid mtu"),
+            UXR_CLIENT_KEY_PATTERN,
+            conversion::clientkey_to_raw(client_representation.client_key()));
+
+        return invalid_result;
+    }
+
     dds::xrce::ResultStatus result_status;
     result_status.status(dds::xrce::STATUS_OK);
 
@@ -74,70 +87,58 @@ dds::xrce::ResultStatus Root::create_client(
     {
         if (client_representation.xrce_version()[0] == dds::xrce::XRCE_VERSION_MAJOR)
         {
-            if (client_representation.mtu() > 0)
+            std::lock_guard<std::mutex> lock(mtx_);
+            dds::xrce::ClientKey client_key = client_representation.client_key();
+            dds::xrce::SessionId session_id = client_representation.session_id();
+            auto it = clients_.find(client_key);
+            if (it == clients_.end())
             {
-                std::lock_guard<std::mutex> lock(mtx_);
-                dds::xrce::ClientKey client_key = client_representation.client_key();
-                dds::xrce::SessionId session_id = client_representation.session_id();
-                auto it = clients_.find(client_key);
-                if (it == clients_.end())
+                std::unordered_map<std::string, std::string> client_properties;
+
+                if (client_representation.properties())
                 {
-                    std::unordered_map<std::string, std::string> client_properties;
-
-                    if (client_representation.properties())
+                    auto v = *client_representation.properties();
+                    for (auto it_props = v.begin(); it_props != v.end(); ++it_props)
                     {
-                        auto v = *client_representation.properties();
-                        for (auto it_props = v.begin(); it_props != v.end(); ++it_props)
-                        {
-                            client_properties.insert(std::pair<std::string, std::string>(it_props->name(), it_props->value()));
-                        }
+                        client_properties.insert(std::pair<std::string, std::string>(it_props->name(), it_props->value()));
                     }
+                }
 
-                    std::shared_ptr<ProxyClient> new_client = std::make_shared<ProxyClient>(
-                        client_representation,
-                        middleware_kind,
-                        std::move(client_properties));
-                    if (clients_.emplace(client_key, std::move(new_client)).second)
-                    {
-                        UXR_AGENT_LOG_INFO(
-                            UXR_DECORATE_GREEN("create"),
-                            UXR_CREATE_SESSION_PATTERN,
-                            conversion::clientkey_to_raw(client_key),
-                            session_id);
-                    }
-                    else
-                    {
-                        result_status.status(dds::xrce::STATUS_ERR_RESOURCES);
-
-                        UXR_AGENT_LOG_INFO(
-                            UXR_DECORATE_RED("resources error"),
-                            UXR_CLIENT_KEY_PATTERN,
-                            conversion::clientkey_to_raw(client_representation.client_key()));
-                    }
+                std::shared_ptr<ProxyClient> new_client = std::make_shared<ProxyClient>(
+                    client_representation,
+                    middleware_kind,
+                    std::move(client_properties));
+                if (clients_.emplace(client_key, std::move(new_client)).second)
+                {
+                    UXR_AGENT_LOG_INFO(
+                        UXR_DECORATE_GREEN("create"),
+                        UXR_CREATE_SESSION_PATTERN,
+                        conversion::clientkey_to_raw(client_key),
+                        session_id);
                 }
                 else
                 {
-                    std::shared_ptr<ProxyClient> client = clients_.at(client_key);
-                    if (session_id != client->get_session_id())
-                    {
-                        it->second = std::make_shared<ProxyClient>(
-                            client_representation,
-                            middleware_kind);
-                    }
-                    else
-                    {
-                        client->session().reset();
-                    }
+                    result_status.status(dds::xrce::STATUS_ERR_RESOURCES);
+
+                    UXR_AGENT_LOG_INFO(
+                        UXR_DECORATE_RED("resources error"),
+                        UXR_CLIENT_KEY_PATTERN,
+                        conversion::clientkey_to_raw(client_representation.client_key()));
                 }
             }
             else
             {
-                result_status.status(dds::xrce::STATUS_ERR_INVALID_DATA);
-
-                UXR_AGENT_LOG_INFO(
-                    UXR_DECORATE_RED("invalid mtu"),
-                    UXR_CLIENT_KEY_PATTERN,
-                    conversion::clientkey_to_raw(client_representation.client_key()));
+                std::shared_ptr<ProxyClient> client = clients_.at(client_key);
+                if (session_id != client->get_session_id())
+                {
+                    it->second = std::make_shared<ProxyClient>(
+                        client_representation,
+                        middleware_kind);
+                }
+                else
+                {
+                    client->session().reset();
+                }
             }
         }
         else

--- a/test/blackbox/tree/TreeTests.cpp
+++ b/test/blackbox/tree/TreeTests.cpp
@@ -48,6 +48,7 @@ TEST_F(TreeTests, XMLTree)
     client_representation.xrce_vendor_id(vendor_id_);
     client_representation.client_key(client_key_);
     client_representation.session_id(0x00);
+    client_representation.mtu(512);
     dds::xrce::ResultStatus response = root_.create_client(
                 client_representation,
                 agent_representation,
@@ -257,6 +258,7 @@ TEST_F(TreeTests, REFTree)
     client_representation.xrce_vendor_id(vendor_id_);
     client_representation.client_key(client_key_);
     client_representation.session_id(0x00);
+    client_representation.mtu(512);
     dds::xrce::ResultStatus response = root_.create_client(
                 client_representation,
                 agent_representation,
@@ -512,6 +514,7 @@ TEST_F(TreeTests, CreationModeXMLTree)
     client_representation.xrce_vendor_id(vendor_id_);
     client_representation.client_key(client_key_);
     client_representation.session_id(0x00);
+    client_representation.mtu(512);
     dds::xrce::ResultStatus response = root_.create_client(
                 client_representation,
                 agent_representation,
@@ -798,6 +801,7 @@ TEST_F(TreeTests, CreationModeREFTree)
     client_representation.xrce_vendor_id(vendor_id_);
     client_representation.client_key(client_key_);
     client_representation.session_id(0x00);
+    client_representation.mtu(512);
     dds::xrce::ResultStatus response = root_.create_client(
                 client_representation,
                 agent_representation,

--- a/test/unittest/Common.cpp
+++ b/test/unittest/Common.cpp
@@ -71,6 +71,7 @@ dds::xrce::CLIENT_Representation CommonData::generate_client_representation() co
     client_representation.client_key(client_key);
     client_representation.session_id();
     client_representation.properties();
+    client_representation.mtu(512);
     return client_representation;
 }
 


### PR DESCRIPTION
Solves https://github.com/eProsima/Micro-XRCE-DDS-Agent/issues/390

Receiving a create_client message with MTU equal to 0 would render the agent unusable due to continuous errors.

Add MTU validation during client creation to prevent this.