### PR TITLE
Catch CDR exceptions

### DIFF
--- a/include/uxr/agent/message/InputMessage.hpp
+++ b/include/uxr/agent/message/InputMessage.hpp
@@ -210,7 +210,7 @@ inline bool InputMessage::deserialize(T& data)
     {
         data.deserialize(deserializer_);
     }
-    catch(eprosima::fastcdr::exception::NotEnoughMemoryException & /*exception*/)
+    catch(eprosima::fastcdr::exception::Exception & /*exception*/)
     {
         log_error();
         rv = false;

--- a/src/cpp/datareader/DataReader.cpp
+++ b/src/cpp/datareader/DataReader.cpp
@@ -56,7 +56,18 @@ std::unique_ptr<DataReader> DataReader::create(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(representation.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            datareader_xrce.deserialize(cdr);
+            try
+            {
+                datareader_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             created_entity = proxy_client->get_middleware().create_datareader_by_bin(raw_object_id, subscriber_id, datareader_xrce);
             break;
@@ -114,7 +125,18 @@ bool DataReader::matched(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(new_object_rep.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            datareader_xrce.deserialize(cdr);
+            try
+            {
+                datareader_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             rv = proxy_client_->get_middleware().matched_datareader_from_bin(get_raw_id(), datareader_xrce);
             break;

--- a/src/cpp/datawriter/DataWriter.cpp
+++ b/src/cpp/datawriter/DataWriter.cpp
@@ -54,7 +54,18 @@ std::unique_ptr<DataWriter> DataWriter::create(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(representation.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            datawriter_xrce.deserialize(cdr);
+            try
+            {
+                datawriter_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             created_entity = proxy_client->get_middleware().create_datawriter_by_bin(raw_object_id, publisher_id, datawriter_xrce);
             break;
@@ -108,7 +119,18 @@ bool DataWriter::matched(const dds::xrce::ObjectVariant& new_object_rep) const
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(new_object_rep.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            datawriter_xrce.deserialize(cdr);
+            try
+            {
+                datawriter_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             rv = proxy_client_->get_middleware().matched_datawriter_from_bin(get_raw_id(), datawriter_xrce);
             break;

--- a/src/cpp/participant/Participant.cpp
+++ b/src/cpp/participant/Participant.cpp
@@ -50,8 +50,18 @@ std::unique_ptr<Participant> Participant::create(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(representation.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            participant_xrce.deserialize(cdr);
-
+            try
+            {
+                participant_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
             created_entity = proxy_client->get_middleware().create_participant_by_bin(raw_object_id, participant_xrce);
             break;
         }
@@ -109,7 +119,18 @@ bool Participant::matched(const dds::xrce::ObjectVariant& new_object_rep) const
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(new_object_rep.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            participant_xrce.deserialize(cdr);
+            try
+            {
+                participant_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             rv = proxy_client_->get_middleware().matched_participant_from_bin(get_raw_id(), domain_id, participant_xrce);
             break;

--- a/src/cpp/publisher/Publisher.cpp
+++ b/src/cpp/publisher/Publisher.cpp
@@ -44,7 +44,18 @@ std::unique_ptr<Publisher> Publisher::create(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(representation.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            publisher_xrce.deserialize(cdr);
+            try
+            {
+                publisher_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             created_entity = proxy_client->get_middleware().create_publisher_by_bin(raw_object_id, participant_id, publisher_xrce);
             break;

--- a/src/cpp/replier/Replier.cpp
+++ b/src/cpp/replier/Replier.cpp
@@ -54,7 +54,18 @@ std::unique_ptr<Replier> Replier::create(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(representation.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            replier_xrce.deserialize(cdr);
+            try
+            {
+                replier_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             created_entity = proxy_client->get_middleware().create_replier_by_bin(raw_object_id, participant_id, replier_xrce);
             break;
@@ -111,7 +122,18 @@ bool Replier::matched(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(new_object_rep.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            replier_xrce.deserialize(cdr);
+            try
+            {
+                replier_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             rv = proxy_client_->get_middleware().matched_replier_from_bin(get_raw_id(), replier_xrce);
             break;

--- a/src/cpp/requester/Requester.cpp
+++ b/src/cpp/requester/Requester.cpp
@@ -56,7 +56,18 @@ std::unique_ptr<Requester> Requester::create(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(representation.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            request_xrce.deserialize(cdr);
+            try
+            {
+                request_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             created_entity = proxy_client->get_middleware().create_requester_by_bin(raw_object_id, participant_id, request_xrce);
             break;
@@ -113,7 +124,18 @@ bool Requester::matched(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(new_object_rep.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            request_xrce.deserialize(cdr);
+            try
+            {
+                request_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             rv = proxy_client_->get_middleware().matched_requester_from_bin(get_raw_id(), request_xrce);
             break;

--- a/src/cpp/subscriber/Subscriber.cpp
+++ b/src/cpp/subscriber/Subscriber.cpp
@@ -44,7 +44,18 @@ std::unique_ptr<Subscriber> Subscriber::create(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(representation.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            subscriber_xrce.deserialize(cdr);
+            try
+            {
+                subscriber_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             created_entity = proxy_client->get_middleware().create_subscriber_by_bin(raw_object_id, participant_id, subscriber_xrce);
             break;

--- a/src/cpp/topic/Topic.cpp
+++ b/src/cpp/topic/Topic.cpp
@@ -51,7 +51,18 @@ std::unique_ptr<Topic> Topic::create(
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(representation.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            topic_xrce.deserialize(cdr);
+            try
+            {
+                topic_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             created_entity = proxy_client->get_middleware().create_topic_by_bin(raw_object_id, participant_id, topic_xrce);
             break;
@@ -106,7 +117,18 @@ bool Topic::matched(const dds::xrce::ObjectVariant& new_object_rep) const
             fastcdr::FastBuffer fastbuffer{reinterpret_cast<char*>(const_cast<uint8_t*>(rep.binary_representation().data())), rep.binary_representation().size()};
             eprosima::fastcdr::Cdr::Endianness endianness = static_cast<eprosima::fastcdr::Cdr::Endianness>(new_object_rep.endianness());
             eprosima::fastcdr::Cdr cdr(fastbuffer, endianness, eprosima::fastcdr::CdrVersion::XCDRv1);
-            topic_xrce.deserialize(cdr);
+            try
+            {
+                topic_xrce.deserialize(cdr);
+            }
+            catch (eprosima::fastcdr::exception::Exception & /*exception*/)
+            {
+                UXR_AGENT_LOG_ERROR(
+                    UXR_DECORATE_RED("deserialization error"),
+                    "buffer: {:X}",
+                    UXR_AGENT_LOG_TO_HEX(fastbuffer.getBuffer(), fastbuffer.getBuffer() + fastbuffer.getBufferSize()));
+                break;
+            }
 
             rv = proxy_client_->get_middleware().matched_topic_from_bin(get_raw_id(), topic_xrce);
             break;


### PR DESCRIPTION
Catch CDR deserialization exceptions.

Previously, uncatched exceptions would terminate the execution of the agent.

Solves https://github.com/eProsima/Micro-XRCE-DDS-Agent/issues/389