### PR TITLE
Add CREATE_TOPIC callback to modify topic attributes from outside

### DIFF
--- a/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
+++ b/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
@@ -276,6 +276,10 @@ public:
             uint16_t replier_id,
             const dds::xrce::OBJK_Replier_Binary& replier_xrce) const override;
 private:
+    std::shared_ptr<FastDDSTopic> create_topic(
+        std::shared_ptr<FastDDSParticipant>& participant,
+        fastrtps::TopicAttributes& attrs);
+
     std::shared_ptr<FastDDSRequester> create_requester(
         std::shared_ptr<FastDDSParticipant>& participant,
         const fastrtps::RequesterAttributes& attrs);

--- a/src/cpp/Agent.cpp
+++ b/src/cpp/Agent.cpp
@@ -18,6 +18,10 @@
 #include <uxr/agent/datawriter/DataWriter.hpp>
 #include <uxr/agent/middleware/utils/Callbacks.hpp>
 
+#ifdef UAGENT_FAST_PROFILE
+#include <fastrtps/attributes/TopicAttributes.h>
+#endif
+
 namespace eprosima {
 namespace uxr {
 
@@ -688,6 +692,10 @@ AGENT_ADD_MW_CB(
     const eprosima::fastdds::dds::DomainParticipant *,
     const eprosima::fastdds::dds::DataWriter *,
     const eprosima::fastdds::dds::DataReader *)
+
+AGENT_ADD_MW_CB(
+    eprosima::fastrtps::TopicAttributes&)
+
 #endif  // UAGENT_FAST_PROFILE
 
 } // namespace uxr

--- a/src/cpp/AgentInstance.cpp
+++ b/src/cpp/AgentInstance.cpp
@@ -170,6 +170,9 @@ AGENTINSTANCE_ADD_MW_CB(
     const eprosima::fastdds::dds::DomainParticipant *,
     const eprosima::fastdds::dds::DataWriter *,
     const eprosima::fastdds::dds::DataReader *)
+
+AGENTINSTANCE_ADD_MW_CB(
+    eprosima::fastrtps::TopicAttributes&)
 #endif  // UAGENT_FAST_PROFILE
 
 } // namespace uxr

--- a/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
@@ -158,11 +158,14 @@ bool FastDDSMiddleware::create_participant_by_bin(
     return rv;
 }
 
-static
-std::shared_ptr<FastDDSTopic> create_topic(
+std::shared_ptr<FastDDSTopic> FastDDSMiddleware::create_topic(
         std::shared_ptr<FastDDSParticipant>& participant,
-        const fastrtps::TopicAttributes& attrs)
+        fastrtps::TopicAttributes& attrs)
 {
+    callback_factory_.execute_callbacks(Middleware::Kind::FASTDDS,
+                    middleware::CallbackKind::CREATE_TOPIC,
+                    &attrs);
+
     std::shared_ptr<FastDDSTopic> topic = participant->find_local_topic(attrs.getTopicName().c_str());
     if (topic)
     {
@@ -502,8 +505,10 @@ std::shared_ptr<FastDDSRequester> FastDDSMiddleware::create_requester(
         const fastrtps::RequesterAttributes& attrs)
 {
     std::shared_ptr<FastDDSRequester> requester{};
-    std::shared_ptr<FastDDSTopic> request_topic = create_topic(participant, attrs.publisher.topic);
-    std::shared_ptr<FastDDSTopic> reply_topic = create_topic(participant, attrs.subscriber.topic);
+    fastrtps::TopicAttributes request_topic_attrs = attrs.publisher.topic;
+    fastrtps::TopicAttributes reply_topic_attrs = attrs.subscriber.topic;
+    std::shared_ptr<FastDDSTopic> request_topic = create_topic(participant, request_topic_attrs);
+    std::shared_ptr<FastDDSTopic> reply_topic = create_topic(participant, reply_topic_attrs);
     if (request_topic && reply_topic)
     {
         requester =
@@ -634,8 +639,10 @@ std::shared_ptr<FastDDSReplier> FastDDSMiddleware::create_replier(
         const fastrtps::ReplierAttributes& attrs)
 {
     std::shared_ptr<FastDDSReplier> replier{};
-    std::shared_ptr<FastDDSTopic> request_topic = create_topic(participant, attrs.subscriber.topic);
-    std::shared_ptr<FastDDSTopic> reply_topic = create_topic(participant, attrs.publisher.topic);
+    fastrtps::TopicAttributes request_topic_attrs = attrs.subscriber.topic;
+    fastrtps::TopicAttributes reply_topic_attrs = attrs.publisher.topic;
+    std::shared_ptr<FastDDSTopic> request_topic = create_topic(participant, request_topic_attrs);
+    std::shared_ptr<FastDDSTopic> reply_topic = create_topic(participant, reply_topic_attrs);
     if (request_topic && reply_topic)
     {
         replier =


### PR DESCRIPTION
CREATE_TOPIC callback enables external programs to access and modify topic attributes before a topic is created