### PR TITLE
FIX: Corrected Fast DDS tag in v2.4.2 build instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ if(UAGENT_FAST_PROFILE)
         set(_fastdds_version 2)
     else()
         set(_fastdds_version 2.12)
-        set(_fastdds_tag 2.12.x)
+        set(_fastdds_tag v2.12.1)
         set(_foonathan_memory_tag v0.7-3) # This tag should be updated every time it gets updated in foonathan_memory_vendor eProsima's package
     endif()
     list(APPEND _deps "fastrtps\;${_fastdds_version}")


### PR DESCRIPTION
# Title
FIX: Corrected Fast DDS tag in v2.4.2 build instructions

Description
This pull request fixes a build failure that occurs when attempting to compile the v2.4.2 release of the Micro-XRCE-DDS-Agent.

The CMakeLists.txt file for this specific version sets the _fastdds_tag variable to 2.12.x. This is a non-existent Git reference, which causes the git clone command in the build process to fail with the error fatal: invalid reference: 2.12.x.

This change corrects the _fastdds_tag to the valid Git tag v2.12.1. This fix ensures that the build process can successfully download the necessary Fast DDS dependency, allowing the v2.4.2 version of the agent to compile without error.

This is a bug fix for a stable release, and it does not introduce new features or change the core behavior of the agent.