### PR TITLE
Move CI from Jenkins to GitHub actions

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -36,8 +36,8 @@ jobs:
 
           # CMake 3.31.8
           CMAKE_VER=3.31.8
-          curl -L "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" -o cmake-old.tgz
-          sudo tar -C /opt -xzf cmake-old.tgz
+          curl -L "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" -o cmake-${CMAKE_VER}.tgz
+          sudo tar -C /opt -xzf cmake-${CMAKE_VER}.tgz
           echo "/opt/cmake-${CMAKE_VER}-linux-x86_64/bin" >> "$GITHUB_PATH"
 
       - name: Show cmake version

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential curl python3-pip git uncrustify valgrind
+          sudo apt-get install -y build-essential curl python3-pip valgrind
           python3 -m pip install --upgrade pip
           python3 -m pip install gcovr
 

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -1,0 +1,114 @@
+name: CI Linux
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "Manual trigger"
+  schedule:
+    - cron: '55 17 * * 6'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  build-test-style-cover:
+    name: Build, Tests, and Coverage
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Install CMake and prerequisites
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential curl python3-pip git uncrustify valgrind
+          python3 -m pip install --upgrade pip
+          python3 -m pip install gcovr
+
+          # CMake 3.31.8
+          CMAKE_VER=3.31.8
+          curl -L "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz" -o cmake-old.tgz
+          sudo tar -C /opt -xzf cmake-old.tgz
+          echo "/opt/cmake-${CMAKE_VER}-linux-x86_64/bin" >> "$GITHUB_PATH"
+
+      - name: Show cmake version
+        run: |
+          cmake --version
+          ctest --version
+
+      - name: Configure
+        run: |
+          mkdir -p build
+          cd build
+          cmake ../ci/linux -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+      - name: Build
+        run: |
+          cd build
+          make -j"$(nproc)"
+
+      # --- Run tests with newer CTest to produce JUnit ---
+      - name: Run tests and export JUnit
+        shell: bash
+        run: |
+          ctest --test-dir build/microxrcedds_agent-build \
+            --output-on-failure \
+            --no-tests=error \
+            --output-junit "$GITHUB_WORKSPACE/build/CTestResults.xml"
+
+      - name: Generate coverage (gcovr Cobertura XML + HTML)
+        shell: bash
+        run: |
+          EXCLUDES=(
+            '--exclude-unreachable-branches'
+            '--exclude' 'build/'
+            '--exclude' 'ci/'
+            '--exclude' 'test/'
+            '--exclude' 'examples/'
+            '--exclude' 'thirdparty/'
+            '--exclude' 'include/uxr/agent/transport/'
+            '--exclude' 'src/cpp/transport/'
+            '--exclude' 'src/cpp/types/XRCETypes.cpp'
+            '--exclude' 'src/cpp/utils/ArgumentParser.cpp'
+            '--exclude' 'include/uxr/agent/utils/ArgumentParser.hpp'
+            '--exclude' 'microxrce_agent.cpp'
+          )
+          gcovr -x -r . "${EXCLUDES[@]}" -o build/coverage.xml
+          gcovr --html-details -r . "${EXCLUDES[@]}" -o build/coverage.html
+          gcovr -r . "${EXCLUDES[@]}" # human-readable summary
+
+      - name: Upload artifacts (CTest & Coverage)
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-and-coverage
+          path: |
+            build/CTestResults.xml
+            build/coverage.xml
+            build/coverage.html
+          if-no-files-found: warn
+
+      - name: Publish unit test results (JUnit)
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: (!cancelled())
+        with:
+          files: build/CTestResults.xml
+          check_run: false
+          comment_mode: failures
+          comment_title: "Linux Tests Results"
+
+  uncrustify:
+    name: Uncrustify check
+    runs-on: ubuntu-22.04
+    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'conflicts') }}
+    steps:
+      - name: Run Uncrustify Linter
+        uses: eProsima/eProsima-CI/ubuntu/uncrustify@v0

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -1,0 +1,91 @@
+name: CI Windows
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "Manual trigger"
+  schedule:
+    - cron: '50 17 * * 6'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  build-and-tests:
+    name: Build and Tests
+    runs-on: windows-2022
+
+    env:
+      TOOLSET: v142
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Install CMake
+        uses: ssrobins/install-cmake@v1
+        with:
+          version: '3.31.8'
+
+      - name: Show tool versions
+        shell: pwsh
+        run: |
+          cmake --version
+          ctest --version
+
+      - name: Configure
+        shell: pwsh
+        run: |
+          mkdir build
+          cd build
+          cmake ..\ci\windows `
+            -G "Visual Studio 17 2022" `
+            -A x64 `
+            -T $env:TOOLSET `
+            -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        shell: pwsh
+        run: |
+          cd build
+          cmake --build . --config Release
+
+      - name: Tests
+        shell: pwsh
+        run: |
+          cd build
+          ctest -N
+
+      - name: Run tests and export JUnit
+        shell: pwsh
+        run: |
+          ctest --test-dir build\microxrcedds_agent-build `
+            -C Release `
+            --output-on-failure `
+            --no-tests=error `
+            --output-junit "$env:GITHUB_WORKSPACE\build\CTestResults.xml"
+          Get-Item "$env:GITHUB_WORKSPACE\build\CTestResults.xml" | Format-List -Property *
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifact
+          path: |
+            build/CTestResults.xml
+          if-no-files-found: error
+
+      - name: Publish unit test results (JUnit)
+        uses: EnricoMi/publish-unit-test-result-action/windows@v2
+        if: (!cancelled())
+        with:
+          files: build/CTestResults.xml
+          check_run: false
+          comment_mode: failures
+          comment_title: "Windows Tests Results"


### PR DESCRIPTION
Migrate CI testing from eProsima's Jenkins infrastructure to GitHub actions.